### PR TITLE
Virtual lines can pad the main buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ variable, their values, and a brief description.
 | `g:molten_image_provider`                     | (`"none"`) \| `"image_nvim"`                                | How image are displayed |
 | `g:molten_output_crop_border`                 | (`true`) \| `false`                                         | 'crops' the bottom border of the output window when it would otherwise just sit at the bottom of the screen |
 | `g:molten_output_show_more`                   | `true` \| (`false`)                                         | When the window can't display the entire contents of the output buffer, shows the number of extra lines in the window footer (requires nvim 10.0+ and a window border) |
+| `g:molten_output_virt_lines`                  | `true` \| (`false`)                                         | Pad the main buffer with virtual lines so the output doesn't cover anything while it's open |
 | `g:molten_output_win_border`                  | (`{ "", "━", "", "" }`) \| any value for `border` in `:h nvim_open_win()`| Some border features will not work if you don't specify your border as a table. see border option of `:h nvim_open_win()` |
 | `g:molten_output_win_cover_gutter`            | (`true`) \| `false`                                         | Should the output window cover the gutter (numbers and sign col), or not. If you change this, you probably also want to change `molten_output_win_style` |
 | `g:molten_output_win_hide_on_leave`           | (`true`) \| `false`                                         | After leaving the output window (via `:q` or switching windows), do not attempt to redraw the output window |
@@ -133,6 +134,7 @@ variable, their values, and a brief description.
 | `g:molten_output_win_style`                   | (`false`) \| `"minimal"`                                    | Value passed to the `style` option in `:h nvim_open_win()` |
 | `g:molten_save_path`                          | (`stdpath("data").."/molten"`) \| any path to a folder      | Where to save/load data with `:MoltenSave` and `:MoltenLoad` |
 | `g:molten_use_border_highlights`              | `true` \| (`false`)                                         | When true, uses different highlights for output border depending on the state of the cell (running, done, error). see [highlights](#highlights) |
+| `g:molten_virt_lines_off_by_1`                | `true` \| (`false`)                                         | _only has effect when `output_virt_lines` is true_ Allows the output window to cover exactly one line of the regular buffer. (useful for running code in a markdown file where that covered line will just be \`\`\`) |
 | `g:molten_wrap_output`                        | `true` \| (`false`)                                         | Wrap text in output windows |
 | [DEBUG] `g:molten_show_mimetype_debug`        | `true` \| (`false`)                                         | Before any non-iostream output chunk, the mime-type for that output chunk is shown. Meant for debugging/plugin devlopment |
 

--- a/rplugin/python3/molten/__init__.py
+++ b/rplugin/python3/molten/__init__.py
@@ -562,4 +562,6 @@ class Molten:
             DynamicPosition(self.nvim, self.extmark_namespace, bufno, start - 1, 0),
             DynamicPosition(self.nvim, self.extmark_namespace, bufno, end - 1, -1),
         )
-        molten.outputs[span] = OutputBuffer(self.nvim, self.canvas, self.options)
+        molten.outputs[span] = OutputBuffer(
+            self.nvim, self.canvas, molten.extmark_namespace, self.options
+        )

--- a/rplugin/python3/molten/io.py
+++ b/rplugin/python3/molten/io.py
@@ -95,13 +95,16 @@ def load(nvim: Nvim, moltenbuffer: MoltenBuffer, nvim_buffer: Buffer, data: Dict
         output.old = True
 
         moltenbuffer.outputs[span] = OutputBuffer(
-            moltenbuffer.nvim, moltenbuffer.canvas, moltenbuffer.options
+            moltenbuffer.nvim,
+            moltenbuffer.canvas,
+            moltenbuffer.extmark_namespace,
+            moltenbuffer.options,
         )
         moltenbuffer.outputs[span].output = output
 
 
 def save(moltenbuffer: MoltenBuffer, nvim_buffer: int) -> Dict[str, Any]:
-    """ Save the current kernel state for the given buffer. """
+    """Save the current kernel state for the given buffer."""
     return {
         "version": 1,
         "kernel": moltenbuffer.runtime.kernel_name,
@@ -127,10 +130,10 @@ def save(moltenbuffer: MoltenBuffer, nvim_buffer: int) -> Dict[str, Any]:
                         "metadata": chunk.jupyter_metadata,
                     }
                     for chunk in output.output.chunks
-                    if chunk.jupyter_data is not None
-                    and chunk.jupyter_metadata is not None
+                    if chunk.jupyter_data is not None and chunk.jupyter_metadata is not None
                 ],
             }
-            for span, output in moltenbuffer.outputs.items() if span.begin.bufno == nvim_buffer
+            for span, output in moltenbuffer.outputs.items()
+            if span.begin.bufno == nvim_buffer
         ],
     }

--- a/rplugin/python3/molten/io.py
+++ b/rplugin/python3/molten/io.py
@@ -89,6 +89,7 @@ def load(nvim: Nvim, moltenbuffer: MoltenBuffer, nvim_buffer: Buffer, data: Dict
                     moltenbuffer.runtime._alloc_file,
                     chunk["data"],
                     chunk["metadata"],
+                    moltenbuffer.options,
                 )
             )
 

--- a/rplugin/python3/molten/moltenbuffer.py
+++ b/rplugin/python3/molten/moltenbuffer.py
@@ -92,7 +92,9 @@ class MoltenBuffer:
             self.outputs[span].clear_interface()
             del self.outputs[span]
 
-        self.outputs[span] = OutputBuffer(self.nvim, self.canvas, self.options)
+        self.outputs[span] = OutputBuffer(
+            self.nvim, self.canvas, self.extmark_namespace, self.options
+        )
         self.queued_outputs.put(span)
 
         self.selected_cell = span
@@ -137,7 +139,9 @@ class MoltenBuffer:
         if self.selected_cell is not None:
             if self.options.enter_output_behavior != "no_open":
                 self.should_show_display_window = True
-            self.should_show_display_window = self.outputs[self.selected_cell].enter(self.selected_cell.end)
+            self.should_show_display_window = self.outputs[self.selected_cell].enter(
+                self.selected_cell.end
+            )
 
     def _get_cursor_position(self) -> Position:
         _, lineno, colno, _, _ = self.nvim.funcs.getcurpos()

--- a/rplugin/python3/molten/options.py
+++ b/rplugin/python3/molten/options.py
@@ -39,10 +39,12 @@ class MoltenOptions:
     output_win_max_height: int
     output_win_max_width: int
     output_win_style: Optional[str]
+    output_virt_lines: bool
     save_path: str
-    use_border_highlights: bool
-    wrap_output: bool
     show_mimetype_debug: bool
+    use_border_highlights: bool
+    virt_lines_off_by_1: bool
+    wrap_output: bool
     nvim: Nvim
     hl: HL
 
@@ -63,10 +65,12 @@ class MoltenOptions:
             ("molten_output_win_max_height", 999999),
             ("molten_output_win_max_width", 999999),
             ("molten_output_win_style", False),
+            ("molten_output_virt_lines", False),
             ("molten_save_path", os.path.join(nvim.funcs.stdpath("data"), "molten")),
-            ("molten_use_border_highlights", False),
-            ("molten_wrap_output", False),
             ("molten_show_mimetype_debug", False),
+            ("molten_use_border_highlights", False),
+            ("molten_virt_lines_off_by_1", False),
+            ("molten_wrap_output", False),
         ]
         # fmt: on
 

--- a/rplugin/python3/molten/outputbuffer.py
+++ b/rplugin/python3/molten/outputbuffer.py
@@ -149,7 +149,7 @@ class OutputBuffer:
             lines = handle_progress_bars(lines_str)
             lineno = len(lines)
         else:
-            lines = [lines_str]
+            lines = []
 
         self.display_buf[0] = self._get_header_text(self.output)
         self.display_buf.append(lines)
@@ -192,7 +192,7 @@ class OutputBuffer:
             if (
                 self.options.output_show_more
                 and not cropped
-                and len(self.display_buf) > height - border_h
+                and height == self.options.output_win_max_height
             ):
                 # the entire window size is shown, but the buffer still has more lines to render
                 hidden_lines = len(self.display_buf) - height

--- a/rplugin/python3/molten/outputbuffer.py
+++ b/rplugin/python3/molten/outputbuffer.py
@@ -6,7 +6,7 @@ from pynvim.api import Buffer, Window
 from molten.images import Canvas
 from molten.outputchunks import Output, OutputStatus
 from molten.options import MoltenOptions
-from molten.utils import Position, notify_error
+from molten.utils import DynamicPosition, Position, notify_error
 
 
 class OutputBuffer:
@@ -17,11 +17,13 @@ class OutputBuffer:
 
     display_buf: Buffer
     display_win: Optional[Window]
+    display_virt_lines: Optional[DynamicPosition]
+    extmark_namespace: int
 
     options: MoltenOptions
     lua: Any
 
-    def __init__(self, nvim: Nvim, canvas: Canvas, options: MoltenOptions):
+    def __init__(self, nvim: Nvim, canvas: Canvas, extmark_namespace: int, options: MoltenOptions):
         self.nvim = nvim
         self.canvas = canvas
 
@@ -29,6 +31,8 @@ class OutputBuffer:
 
         self.display_buf = self.nvim.buffers[self.nvim.funcs.nvim_create_buf(False, True)]
         self.display_win = None
+        self.display_virt_lines = None
+        self.extmark_namespace = extmark_namespace
 
         self.options = options
         self.nvim.exec_lua("_ow = require('output_window')")
@@ -86,6 +90,9 @@ class OutputBuffer:
             self.nvim.funcs.nvim_win_close(self.display_win, True)
             self.canvas.clear()
             self.display_win = None
+        if self.display_virt_lines is not None:
+            del self.display_virt_lines
+            self.display_virt_lines = None
 
     def set_win_option(self, option: str, value) -> None:
         if self.display_win:
@@ -185,7 +192,6 @@ class OutputBuffer:
             if (
                 self.options.output_show_more
                 and not cropped
-                and height == self.options.output_win_max_height
                 and len(self.display_buf) > height - border_h
             ):
                 # the entire window size is shown, but the buffer still has more lines to render
@@ -216,6 +222,20 @@ class OutputBuffer:
                 self.canvas.present()
             else:  # move the current window
                 self.display_win.api.set_config(win_opts)
+
+            if self.display_virt_lines is not None:
+                del self.display_virt_lines
+
+            if self.options.output_virt_lines:
+                virt_lines_y = anchor.lineno
+                virt_lines_height = max_height + border_h
+                if self.options.virt_lines_off_by_1:
+                    virt_lines_y += 1
+                    virt_lines_height -= 1
+                self.display_virt_lines = DynamicPosition(
+                    self.nvim, self.extmark_namespace, anchor.bufno, virt_lines_y, 0
+                )
+                self.display_virt_lines.set_height(virt_lines_height)
 
     def set_border_highlight(self, border):
         hl = self.options.hl.border_norm

--- a/rplugin/python3/molten/runtime.py
+++ b/rplugin/python3/molten/runtime.py
@@ -108,7 +108,9 @@ class JupyterRuntime:
             output.chunks.append(MimetypesOutputChunk(list(data.keys())))
 
         if output.success:
-            output.chunks.append(to_outputchunk(self.nvim, self._alloc_file, data, metadata))
+            output.chunks.append(
+                to_outputchunk(self.nvim, self._alloc_file, data, metadata, self.options)
+            )
 
     def _tick_one(self, output: Output, message_type: str, content: Dict[str, Any]) -> bool:
         def copy_on_demand(content_ctor):

--- a/rplugin/python3/molten/utils.py
+++ b/rplugin/python3/molten/utils.py
@@ -81,7 +81,17 @@ class DynamicPosition(Position):
             self.bufno, extmark_namespace, lineno, colno, {}
         )
 
+    def set_height(self, height: int) -> None:
+        self.nvim.funcs.nvim_buf_set_extmark(
+            self.bufno, self.extmark_namespace, self.lineno, self.colno,
+            {
+                "id": self.extmark_id,
+                "virt_lines": [[("", "Normal")] for _ in range(height)]
+            }
+        )
+
     def __del__(self) -> None:
+        # Note, this will not fail if the extmark doesn't exist
         self.nvim.funcs.nvim_buf_del_extmark(self.bufno, self.extmark_namespace, self.extmark_id)
 
     def _get_pos(self) -> List[int]:


### PR DESCRIPTION
When an output window is open, optionally pad the main buffer with virtual text so that the output window doesn't cover any text. 

## feat

- `molten_output_virt_lines` to add the virtual text padding, off by default
- `molten_virt_lines_off_by_1` to hid one line below the code cell (useful for notebooks) off by default

## fix

- No longer attempt to render images when the image provider in "none". Prevent conflicts when image provider is none, but the user has installed cairo and/or pnglatex
- No longer render a single empty line under a cell that doesn't have any output