### PR TITLE
feat: Output as Virtual Text

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,12 +164,12 @@ variable, their values, and a brief description.
 | `g:molten_output_win_hide_on_leave`           | (`true`) \| `false`                                         | After leaving the output window (via `:q` or switching windows), do not attempt to redraw the output window |
 | `g:molten_output_win_max_height`              | (`999999`) \| int                                           | Max height of the output window |
 | `g:molten_output_win_max_width`               | (`999999`) \| int                                           | Max width of the output window |
-| `g:molten_output_as_virtual_text`             | `true` \| (`false`)                                         | When true, show output as virtual text below the cell. When true, output window doesn't open automatically on run. Effected by `virt_lines_off_by_1` |
-| `g:molten_virtual_text_max_lines`             | (`12`) \| int                                               | Max height of the virtual text |
 | `g:molten_output_win_style`                   | (`false`) \| `"minimal"`                                    | Value passed to the `style` option in `:h nvim_open_win()` |
 | `g:molten_save_path`                          | (`stdpath("data").."/molten"`) \| any path to a folder      | Where to save/load data with `:MoltenSave` and `:MoltenLoad` |
 | `g:molten_use_border_highlights`              | `true` \| (`false`)                                         | When true, uses different highlights for output border depending on the state of the cell (running, done, error). see [highlights](#highlights) |
-| `g:molten_virt_lines_off_by_1`                | `true` \| (`false`)                                         | _only has effect when `output_virt_lines` is true_ Allows the output window to cover exactly one line of the regular buffer. (useful for running code in a markdown file where that covered line will just be \`\`\`) |
+| `g:molten_virt_lines_off_by_1`                | `true` \| (`false`)                                         | Allows the output window to cover exactly one line of the regular buffer when `output_virt_lines` is true, also effects `virt_text_output`. (useful for running code in a markdown file where that covered line will just be \`\`\`) |
+| `g:molten_virt_text_output`                   | `true` \| (`false`)                                         | When true, show output as virtual text below the cell. When true, output window doesn't open automatically on run. Effected by `virt_lines_off_by_1` |
+| `g:molten_virt_text_max_lines`                | (`12`) \| int                                               | Max height of the virtual text |
 | `g:molten_wrap_output`                        | `true` \| (`false`)                                         | Wrap text in output windows |
 | [DEBUG] `g:molten_show_mimetype_debug`        | `true` \| (`false`)                                         | Before any non-iostream output chunk, the mime-type for that output chunk is shown. Meant for debugging/plugin devlopment |
 

--- a/README.md
+++ b/README.md
@@ -164,6 +164,8 @@ variable, their values, and a brief description.
 | `g:molten_output_win_hide_on_leave`           | (`true`) \| `false`                                         | After leaving the output window (via `:q` or switching windows), do not attempt to redraw the output window |
 | `g:molten_output_win_max_height`              | (`999999`) \| int                                           | Max height of the output window |
 | `g:molten_output_win_max_width`               | (`999999`) \| int                                           | Max width of the output window |
+| `g:molten_output_as_virtual_text`             | `true` \| (`false`)                                         | When true, show output as virtual text below the cell. When true, output window doesn't open automatically on run. Effected by `virt_lines_off_by_1` |
+| `g:molten_virtual_text_max_lines`             | (`12`) \| int                                               | Max height of the virtual text |
 | `g:molten_output_win_style`                   | (`false`) \| `"minimal"`                                    | Value passed to the `style` option in `:h nvim_open_win()` |
 | `g:molten_save_path`                          | (`stdpath("data").."/molten"`) \| any path to a folder      | Where to save/load data with `:MoltenSave` and `:MoltenLoad` |
 | `g:molten_use_border_highlights`              | `true` \| (`false`)                                         | When true, uses different highlights for output border depending on the state of the cell (running, done, error). see [highlights](#highlights) |
@@ -204,6 +206,7 @@ Here is a complete list of the highlight groups that Molten uses, and their defa
 - `MoltenOutputWinNC` = `MoltenOutputWin`: a "Non-Current" output window
 - `MoltenOutputFooter` = `FloatFooter`: the "x more lines" text
 - `MoltenCell` = `CursorLine`: applied to code that makes up a cell
+- `MoltenVirtualText` = `Comment`: output that is rendered as virtual text
 
 ## Autocommands
 

--- a/lua/output_window.lua
+++ b/lua/output_window.lua
@@ -1,49 +1,14 @@
 
 local M = {}
 
----Calculate the y position of the output window, accounting for folds, extmarks, and scroll.
----@param buf number
+---Calculate the y position of the output window
 ---@param buf_line number
 ---@return number
-M.calculate_window_position = function(buf, buf_line)
-  -- code modified from image.nvim https://github.com/3rd/image.nvim/blob/16f54077ca91fa8c4d1239cc3c1b6663dd169092/lua/image/renderer.lua#L254
-  local win_top = vim.fn.line("w0")
-  if win_top == nil then return buf_line end
-  local offset = 0
+M.calculate_window_position = function(buf_line)
+  local win = vim.api.nvim_get_current_win()
+  local pos = vim.fn.screenpos(win, buf_line, 0)
 
-  if vim.wo.foldenable then
-    local i = win_top
-    while i <= buf_line do
-      local fold_start, fold_end = vim.fn.foldclosed(i), vim.fn.foldclosedend(i)
-
-      if fold_start ~= -1 and fold_end ~= -1 then
-        offset = offset + (fold_end - fold_start)
-        i = fold_end + 1
-      else
-        i = i + 1
-      end
-    end
-  end
-
-  local extmarks = vim.tbl_map(
-    function(mark)
-      local mark_id, mark_row, mark_col, mark_opts = unpack(mark)
-      local virt_height = #(mark_opts.virt_lines or {})
-      return { id = mark_id, row = mark_row, col = mark_col, height = virt_height }
-    end,
-    vim.api.nvim_buf_get_extmarks(
-      buf,
-      -1,
-      { win_top - 1, 0 },
-      { buf_line - 1, 0 },
-      { details = true }
-    )
-  )
-  for _, mark in ipairs(extmarks) do
-    if mark.row + 1 ~= buf_line then offset = offset - mark.height end
-  end
-
-  return buf_line - win_top + 1 - offset
+  return pos.row
 end
 
 return M

--- a/rplugin/python3/molten/__init__.py
+++ b/rplugin/python3/molten/__init__.py
@@ -648,7 +648,7 @@ class Molten:
 
         for molten in molten_kernels:
             if molten.current_output is not None:
-                molten.should_show_display_window = True
+                molten.should_show_floating_window = True
                 self._update_interface()
                 return
 
@@ -672,7 +672,7 @@ class Molten:
             return
 
         for molten in molten_kernels:
-            molten.should_show_display_window = False
+            molten.should_show_floating_window = False
 
         self._update_interface()
 

--- a/rplugin/python3/molten/__init__.py
+++ b/rplugin/python3/molten/__init__.py
@@ -648,7 +648,7 @@ class Molten:
 
         for molten in molten_kernels:
             if molten.current_output is not None:
-                molten.should_show_floating_window = True
+                molten.should_show_floating_win = True
                 self._update_interface()
                 return
 
@@ -672,7 +672,7 @@ class Molten:
             return
 
         for molten in molten_kernels:
-            molten.should_show_floating_window = False
+            molten.should_show_floating_win = False
 
         self._update_interface()
 

--- a/rplugin/python3/molten/images.py
+++ b/rplugin/python3/molten/images.py
@@ -1,7 +1,9 @@
 from typing import Dict, Set
 from abc import ABC, abstractmethod
 
-from pynvim import Nvim, logging
+from pynvim import Nvim
+
+from molten.utils import notify_warn
 
 
 class Canvas(ABC):
@@ -101,8 +103,6 @@ class NoCanvas(Canvas):
         pass
 
 
-# I think this class will end up being calls to equivalent lua functions in some lua file
-# somewhere
 class ImageNvimCanvas(Canvas):
     nvim: Nvim
     to_make_visible: Set[str]
@@ -180,9 +180,5 @@ def get_canvas_given_provider(name: str, nvim: Nvim) -> Canvas:
     elif name == "image.nvim":
         return ImageNvimCanvas(nvim)
     else:
-        nvim.api.notify(
-            f"[Molten] unknown image provider: `{name}`",
-            logging.ERROR,
-            {"title": "Molten"},
-        )
+        notify_warn(nvim, f"unknown image provider: `{name}`")
         return NoCanvas()

--- a/rplugin/python3/molten/moltenbuffer.py
+++ b/rplugin/python3/molten/moltenbuffer.py
@@ -34,7 +34,7 @@ class MoltenKernel:
     queued_outputs: "Queue[CodeCell]"
 
     selected_cell: Optional[CodeCell]
-    should_show_display_window: bool
+    should_show_floating_win: bool
     updating_interface: bool
 
     options: MoltenOptions
@@ -66,7 +66,7 @@ class MoltenKernel:
         self.queued_outputs = Queue()
 
         self.selected_cell = None
-        self.should_show_display_window = False
+        self.should_show_floating_win = False
         self.updating_interface = False
 
         self.options = options
@@ -106,7 +106,7 @@ class MoltenKernel:
         self.selected_cell = span
 
         if not self.options.output_as_virtual_text:
-            self.should_show_display_window = True
+            self.should_show_floating_win = True
 
         self.update_interface()
 
@@ -148,8 +148,8 @@ class MoltenKernel:
     def enter_output(self) -> None:
         if self.selected_cell is not None:
             if self.options.enter_output_behavior != "no_open":
-                self.should_show_display_window = True
-            self.should_show_display_window = self.outputs[self.selected_cell].enter(
+                self.should_show_floating_win = True
+            self.should_show_floating_win = self.outputs[self.selected_cell].enter(
                 self.selected_cell.end
             )
 
@@ -222,7 +222,7 @@ class MoltenKernel:
             self.selected_cell.clear_interface(self.highlight_namespace)
 
         if new_selected_cell is None:
-            self.should_show_display_window = False
+            self.should_show_floating_win = False
 
         self.selected_cell = new_selected_cell
 
@@ -244,13 +244,13 @@ class MoltenKernel:
             and new_selected_cell is not None
             and self.options.auto_open_output
         ):
-            self.should_show_display_window = True
+            self.should_show_floating_win = True
 
         if self.selected_cell == new_selected_cell and new_selected_cell is not None:
             if (
                 scrolled
                 and new_selected_cell.end.lineno < self.nvim.funcs.line("w$")
-                and self.should_show_display_window
+                and self.should_show_floating_win
             ):
                 self.update_interface()
             return
@@ -299,7 +299,7 @@ class MoltenKernel:
                 span.end.colno,
             )
 
-        if self.should_show_display_window:
+        if self.should_show_floating_win:
             self.outputs[span].show_floating_win(span.end)
         else:
             self.outputs[span].clear_float_win()

--- a/rplugin/python3/molten/moltenbuffer.py
+++ b/rplugin/python3/molten/moltenbuffer.py
@@ -105,7 +105,7 @@ class MoltenKernel:
 
         self.selected_cell = span
 
-        if not self.options.output_as_virtual_text:
+        if not self.options.virt_text_output:
             self.should_show_floating_win = True
 
         self.update_interface()
@@ -230,7 +230,7 @@ class MoltenKernel:
             self._show_selected(self.selected_cell)
         self.canvas.present()
 
-        if self.options.output_as_virtual_text:
+        if self.options.virt_text_output:
             for span, output in self.outputs.items():
                 output.show_virtual_output(span.end)
 

--- a/rplugin/python3/molten/moltenbuffer.py
+++ b/rplugin/python3/molten/moltenbuffer.py
@@ -34,7 +34,7 @@ class MoltenKernel:
     queued_outputs: "Queue[CodeCell]"
 
     selected_cell: Optional[CodeCell]
-    should_show_display_window: bool
+    should_show_floating_window: bool
     updating_interface: bool
 
     options: MoltenOptions
@@ -66,7 +66,7 @@ class MoltenKernel:
         self.queued_outputs = Queue()
 
         self.selected_cell = None
-        self.should_show_display_window = False
+        self.should_show_floating_window = False
         self.updating_interface = False
 
         self.options = options
@@ -107,7 +107,7 @@ class MoltenKernel:
         self.queued_outputs.put(span)
 
         self.selected_cell = span
-        self.should_show_display_window = True
+        self.should_show_floating_window = True
         self.update_interface()
 
         self._check_if_done_running()
@@ -148,8 +148,8 @@ class MoltenKernel:
     def enter_output(self) -> None:
         if self.selected_cell is not None:
             if self.options.enter_output_behavior != "no_open":
-                self.should_show_display_window = True
-            self.should_show_display_window = self.outputs[self.selected_cell].enter(
+                self.should_show_floating_window = True
+            self.should_show_floating_window = self.outputs[self.selected_cell].enter(
                 self.selected_cell.end
             )
 
@@ -221,7 +221,7 @@ class MoltenKernel:
             self.selected_cell.clear_interface(self.highlight_namespace)
 
         if selected_cell is None:
-            self.should_show_display_window = False
+            self.should_show_floating_window = False
 
         self.selected_cell = selected_cell
 
@@ -239,13 +239,13 @@ class MoltenKernel:
             and selected_cell is not None
             and self.options.auto_open_output
         ):
-            self.should_show_display_window = True
+            self.should_show_floating_window = True
 
         if self.selected_cell == selected_cell and selected_cell is not None:
             if (
                 scrolled
                 and selected_cell.end.lineno < self.nvim.funcs.line("w$")
-                and self.should_show_display_window
+                and self.should_show_floating_window
             ):
                 self.update_interface()
             return
@@ -294,8 +294,8 @@ class MoltenKernel:
                 span.end.colno,
             )
 
-        if self.should_show_display_window:
-            self.outputs[span].show(span.end)
+        if self.should_show_floating_window:
+            self.outputs[span].show_floating_win(span.end)
         else:
             self.outputs[span].clear_interface()
 

--- a/rplugin/python3/molten/options.py
+++ b/rplugin/python3/molten/options.py
@@ -71,8 +71,7 @@ class MoltenOptions:
             ("molten_output_win_max_height", 999999),
             ("molten_output_win_max_width", 999999),
             ("molten_output_win_style", False),
-            # TODO: default to false
-            ("molten_output_as_virtual_text", True),
+            ("molten_output_as_virtual_text", False),
             ("molten_virtual_text_max_lines", 12),
             ("molten_output_virt_lines", False),
             ("molten_save_path", os.path.join(nvim.funcs.stdpath("data"), "molten")),

--- a/rplugin/python3/molten/options.py
+++ b/rplugin/python3/molten/options.py
@@ -26,7 +26,7 @@ class HL:
         win_nc: win,
         foot: "FloatFooter",
         cell: "CursorLine",
-        virtual_text: "Type",
+        virtual_text: "Comment",
     }
 
 
@@ -73,7 +73,7 @@ class MoltenOptions:
             ("molten_output_win_style", False),
             # TODO: default to false
             ("molten_output_as_virtual_text", True),
-            ("molten_virtual_text_max_lines", 15),
+            ("molten_virtual_text_max_lines", 12),
             ("molten_output_virt_lines", False),
             ("molten_save_path", os.path.join(nvim.funcs.stdpath("data"), "molten")),
             ("molten_show_mimetype_debug", False),

--- a/rplugin/python3/molten/options.py
+++ b/rplugin/python3/molten/options.py
@@ -37,20 +37,19 @@ class MoltenOptions:
     image_provider: str
     output_crop_border: bool
     output_show_more: bool
+    output_virt_lines: bool
     output_win_border: Union[str, List[str]]
     output_win_cover_gutter: bool
     output_win_hide_on_leave: bool
     output_win_max_height: int
     output_win_max_width: int
     output_win_style: Optional[str]
-    output_virt_lines: bool
-    virt_text_output: bool
-    virt_text_max_lines: int
-    virt_text_border: Optional[str]
     save_path: str
     show_mimetype_debug: bool
     use_border_highlights: bool
     virt_lines_off_by_1: bool
+    virt_text_max_lines: int
+    virt_text_output: bool
     wrap_output: bool
     nvim: Nvim
     hl: HL
@@ -66,19 +65,19 @@ class MoltenOptions:
             ("molten_image_provider", "none"),
             ("molten_output_crop_border", True),
             ("molten_output_show_more", False),
+            ("molten_output_virt_lines", False),
             ("molten_output_win_border", [ "", "━", "", "" ]),
             ("molten_output_win_cover_gutter", True),
             ("molten_output_win_hide_on_leave", True),
             ("molten_output_win_max_height", 999999),
             ("molten_output_win_max_width", 999999),
             ("molten_output_win_style", False),
-            ("molten_output_as_virt_text", False),
-            ("molten_virt_text_max_lines", 12),
-            ("molten_output_virt_lines", False),
             ("molten_save_path", os.path.join(nvim.funcs.stdpath("data"), "molten")),
             ("molten_show_mimetype_debug", False),
             ("molten_use_border_highlights", False),
             ("molten_virt_lines_off_by_1", False),
+            ("molten_virt_text_max_lines", 12),
+            ("molten_virt_text_output", False),
             ("molten_wrap_output", False),
         ]
         # fmt: on

--- a/rplugin/python3/molten/options.py
+++ b/rplugin/python3/molten/options.py
@@ -16,6 +16,7 @@ class HL:
     win_nc = "MoltenOutputWinNC"
     foot = "MoltenOutputFooter"
     cell = "MoltenCell"
+    virtual_text = "MoltenVirtualText"
 
     defaults = {
         border_norm: "FloatBorder",
@@ -25,6 +26,7 @@ class HL:
         win_nc: win,
         foot: "FloatFooter",
         cell: "CursorLine",
+        virtual_text: "Type",
     }
 
 
@@ -42,6 +44,8 @@ class MoltenOptions:
     output_win_max_width: int
     output_win_style: Optional[str]
     output_virt_lines: bool
+    output_as_virtual_text: bool
+    virtual_text_max_lines: int
     save_path: str
     show_mimetype_debug: bool
     use_border_highlights: bool
@@ -67,6 +71,9 @@ class MoltenOptions:
             ("molten_output_win_max_height", 999999),
             ("molten_output_win_max_width", 999999),
             ("molten_output_win_style", False),
+            # TODO: default to false
+            ("molten_output_as_virtual_text", True),
+            ("molten_virtual_text_max_lines", 15),
             ("molten_output_virt_lines", False),
             ("molten_save_path", os.path.join(nvim.funcs.stdpath("data"), "molten")),
             ("molten_show_mimetype_debug", False),

--- a/rplugin/python3/molten/options.py
+++ b/rplugin/python3/molten/options.py
@@ -44,8 +44,9 @@ class MoltenOptions:
     output_win_max_width: int
     output_win_style: Optional[str]
     output_virt_lines: bool
-    output_as_virtual_text: bool
-    virtual_text_max_lines: int
+    virt_text_output: bool
+    virt_text_max_lines: int
+    virt_text_border: Optional[str]
     save_path: str
     show_mimetype_debug: bool
     use_border_highlights: bool
@@ -71,8 +72,8 @@ class MoltenOptions:
             ("molten_output_win_max_height", 999999),
             ("molten_output_win_max_width", 999999),
             ("molten_output_win_style", False),
-            ("molten_output_as_virtual_text", False),
-            ("molten_virtual_text_max_lines", 12),
+            ("molten_output_as_virt_text", False),
+            ("molten_virt_text_max_lines", 12),
             ("molten_output_virt_lines", False),
             ("molten_save_path", os.path.join(nvim.funcs.stdpath("data"), "molten")),
             ("molten_show_mimetype_debug", False),

--- a/rplugin/python3/molten/outputbuffer.py
+++ b/rplugin/python3/molten/outputbuffer.py
@@ -43,8 +43,8 @@ class OutputBuffer:
         self.nvim.exec_lua("_ow = require('output_window')")
         self.lua = self.nvim.lua._ow
 
-    def _buffer_to_window_lineno(self, lineno: int, bufno: int) -> int:
-        return self.lua.calculate_window_position(bufno, lineno)
+    def _buffer_to_window_lineno(self, lineno: int) -> int:
+        return self.lua.calculate_window_position(lineno)
 
     def _get_header_text(self, output: Output) -> str:
         if output.execution_count is None:
@@ -182,7 +182,7 @@ class OutputBuffer:
     def show_floating_win(self, anchor: Position) -> None:
         win = self.nvim.current.window
         win_col = win.col
-        win_row = self._buffer_to_window_lineno(anchor.lineno + 1, anchor.bufno)
+        win_row = self._buffer_to_window_lineno(anchor.lineno + 1)
         win_width = win.width
         win_height = win.height
 
@@ -207,7 +207,9 @@ class OutputBuffer:
         )
         lines, real_height = self.build_output_text(shape, False)
 
-        self.display_buf.append(lines)
+        # You can't append lines normally, there will be a blank line at the top
+        self.display_buf[0] = lines[0]
+        self.display_buf.append(lines[1:])
         self.nvim.api.set_option_value(
             "filetype", "molten_output", {"buf": self.display_buf.handle}
         )

--- a/rplugin/python3/molten/outputbuffer.py
+++ b/rplugin/python3/molten/outputbuffer.py
@@ -149,7 +149,9 @@ class OutputBuffer:
 
         # clear the existing virtual text
         if self.virt_text_id is not None:
-            self.nvim.funcs.nvim_buf_del_extmark(anchor.bufno, self.extmark_namespace, self.virt_text_id)
+            self.nvim.funcs.nvim_buf_del_extmark(
+                anchor.bufno, self.extmark_namespace, self.virt_text_id
+            )
             self.virt_text_id = None
 
         win = self.nvim.current.window
@@ -179,7 +181,7 @@ class OutputBuffer:
             0,
             {
                 "virt_lines": [[(line, self.options.hl.virtual_text)] for line in lines],
-            }
+            },
         )
         self.canvas.present()
 

--- a/rplugin/python3/molten/outputbuffer.py
+++ b/rplugin/python3/molten/outputbuffer.py
@@ -189,6 +189,8 @@ class OutputBuffer:
         win = self.nvim.current.window
         win_col = win.col
         win_row = self._buffer_to_window_lineno(anchor.lineno + 1)
+        if win_row == 0: # anchor position is off screen
+            return
         win_width = win.width
         win_height = win.height
 

--- a/rplugin/python3/molten/outputbuffer.py
+++ b/rplugin/python3/molten/outputbuffer.py
@@ -168,10 +168,10 @@ class OutputBuffer:
             win_height,
         )
         lines, _ = self.build_output_text(shape, anchor.bufno, True)
-        if len(lines) > self.options.virtual_text_max_lines:
-            l = len(lines)
-            lines = lines[: self.options.virtual_text_max_lines - 1]
-            lines.append(f"󰁅 {l - self.options.virtual_text_max_lines} More Lines ")
+        l = len(lines)
+        if l > self.options.virt_text_max_lines:
+            lines = lines[: self.options.virt_text_max_lines - 1]
+            lines.append(f"󰁅 {l - self.options.virt_text_max_lines} More Lines ")
 
         self.virt_text_id = self.nvim.current.buffer.api.set_extmark(
             self.extmark_namespace,

--- a/rplugin/python3/molten/outputbuffer.py
+++ b/rplugin/python3/molten/outputbuffer.py
@@ -21,6 +21,7 @@ class OutputBuffer:
     display_virt_lines: Optional[DynamicPosition]
     extmark_namespace: int
     virt_text_id: Optional[int]
+    displayed_status: OutputStatus
 
     options: MoltenOptions
     lua: Any
@@ -36,6 +37,7 @@ class OutputBuffer:
         self.display_virt_lines = None
         self.extmark_namespace = extmark_namespace
         self.virt_text_id = None
+        self.displayed_status = OutputStatus.HOLD
 
         self.options = options
         self.nvim.exec_lua("_ow = require('output_window')")
@@ -88,7 +90,7 @@ class OutputBuffer:
                 return False
         return True
 
-    def clear_interface(self, bufnr: int) -> None:
+    def clear_float_win(self) -> None:
         if self.display_win is not None:
             self.nvim.funcs.nvim_win_close(self.display_win, True)
             self.canvas.clear()
@@ -96,6 +98,8 @@ class OutputBuffer:
         if self.display_virt_lines is not None:
             del self.display_virt_lines
             self.display_virt_lines = None
+
+    def clear_virt_output(self, bufnr: int) -> None:
         if self.virt_text_id is not None:
             self.nvim.funcs.nvim_buf_del_extmark(bufnr, self.extmark_namespace, self.virt_text_id)
 
@@ -107,7 +111,7 @@ class OutputBuffer:
                 {"scope": "local", "win": self.display_win.handle},
             )
 
-    def build_output(self, shape, hard_wrap: bool) -> Tuple[List[str], int]:
+    def build_output_text(self, shape, hard_wrap: bool) -> Tuple[List[str], int]:
         lineno = 0
         lines_str = ""
         # images are rendered with virtual lines by image.nvim
@@ -134,10 +138,16 @@ class OutputBuffer:
         lines.insert(0, self._get_header_text(self.output))
         return lines, lineno + virtual_lines
 
-    def show_virtual_text(self, anchor: Position) -> None:
+    def show_virtual_output(self, anchor: Position) -> None:
+        if self.displayed_status == OutputStatus.DONE and self.virt_text_id is not None:
+            return
+
+        self.displayed_status = self.output.status
+
         # clear the existing virtual text
         if self.virt_text_id is not None:
             self.nvim.funcs.nvim_buf_del_extmark(anchor.bufno, self.extmark_namespace, self.virt_text_id)
+            self.virt_text_id = None
 
         win = self.nvim.current.window
         win_col = win.col
@@ -154,11 +164,12 @@ class OutputBuffer:
             win_width,
             win_height,
         )
-        lines, _ = self.build_output(shape, True)
+        lines, _ = self.build_output_text(shape, True)
         if len(lines) > self.options.virtual_text_max_lines:
             l = len(lines)
             lines = lines[: self.options.virtual_text_max_lines - 1]
             lines.append(f"󰁅 {l - self.options.virtual_text_max_lines} More Lines ")
+
         self.virt_text_id = self.nvim.current.buffer.api.set_extmark(
             self.extmark_namespace,
             win_row,
@@ -194,9 +205,8 @@ class OutputBuffer:
             win_width - sign_col_width,
             win_height,
         )
-        lines, real_height = self.build_output(shape, False)
+        lines, real_height = self.build_output_text(shape, False)
 
-        self.display_buf[0] = self._get_header_text(self.output)
         self.display_buf.append(lines)
         self.nvim.api.set_option_value(
             "filetype", "molten_output", {"buf": self.display_buf.handle}

--- a/rplugin/python3/molten/outputchunks.py
+++ b/rplugin/python3/molten/outputchunks.py
@@ -133,7 +133,6 @@ class ImageOutputChunk(OutputChunk):
         canvas: Canvas,
         _hard_wrap: bool,
     ) -> Tuple[str, int]:
-        # _x, _y, win_w, win_h = shape
         img = canvas.add_image(
             self.img_path,
             x=0,


### PR DESCRIPTION
resolves #19 

Adds the ability to render output as virtual text in the buffer. This solves the problem of keeping multiple outputs open at once.

When virtual text output is enabled, output windows aren't automatically shown on run. But you can still open them.

still TODO:
- [x] Set proper default values
- [x] README
- [x] Images don't render in virtual text yet
~~- [ ] configurable top and bottom borders (probably just going to use the same as the output window)~~
- [x] output window rendering bugs exist (line height)
- [x] floating window has two top lines now