### PR TITLE
fix: images being pushed down doubly by virt text

### DIFF
--- a/rplugin/python3/molten/outputbuffer.py
+++ b/rplugin/python3/molten/outputbuffer.py
@@ -134,7 +134,7 @@ class OutputBuffer:
             for chunk in self.output.chunks:
                 y = lineno
                 if virtual:
-                    y += shape[1]
+                    y = shape[1]
                 chunktext, virt_lines = chunk.place(
                     buf,
                     self.options,


### PR DESCRIPTION
fixes #52

In floating output windows the image's position is affected by text output, so that's added to the image position. But in virtual text the image line number is entirely determined by the output's position and then by the way neovim renders extmarks.
