### PR TITLE
fix: images in output windows with virt text

### DIFF
--- a/rplugin/python3/molten/images.py
+++ b/rplugin/python3/molten/images.py
@@ -50,6 +50,7 @@ class Canvas(ABC):
     def add_image(
         self,
         path: str,
+        identifier: str,
         x: int,
         y: int,
         bufnr: int,
@@ -108,6 +109,7 @@ class NoCanvas(Canvas):
     def add_image(
         self,
         _path: str,
+        _identifier: str,
         _x: int,
         _y: int,
         _window: int,
@@ -169,6 +171,7 @@ class ImageNvimCanvas(Canvas):
     def add_image(
         self,
         path: str,
+        identifier: str,
         x: int,
         y: int,
         bufnr: int,
@@ -177,7 +180,7 @@ class ImageNvimCanvas(Canvas):
             img = self.image_api.from_file(
                 path,
                 {
-                    "id": path,
+                    "id": identifier,
                     "buffer": bufnr,
                     "with_virtual_padding": True,
                     "x": x,

--- a/rplugin/python3/molten/moltenbuffer.py
+++ b/rplugin/python3/molten/moltenbuffer.py
@@ -234,11 +234,12 @@ class MoltenKernel:
 
         if self.selected_cell is not None:
             self._show_selected(self.selected_cell)
-        self.canvas.present()
 
         if self.options.virt_text_output:
             for span, output in self.outputs.items():
                 output.show_virtual_output(span.end)
+
+        self.canvas.present()
 
         self.updating_interface = False
 

--- a/rplugin/python3/molten/outputchunks.py
+++ b/rplugin/python3/molten/outputchunks.py
@@ -135,10 +135,11 @@ class ImageOutputChunk(OutputChunk):
         lineno: int,
         _shape: Tuple[int, int, int, int],
         canvas: Canvas,
-        _hard_wrap: bool,
+        virtual: bool,
     ) -> Tuple[str, int]:
         self.img_identifier = canvas.add_image(
             self.img_path,
+            f"{'virt-' if virtual else ''}{self.img_path}",
             x=0,
             y=lineno + 1,
             bufnr=bufnr,


### PR DESCRIPTION
fixes #48


images in the main buffer now get different image ids to the images in floating buffers
