### PR TITLE
fix: healthcheck on python 3.11+

### DIFF
--- a/lua/molten/health.lua
+++ b/lua/molten/health.lua
@@ -1,6 +1,7 @@
 local M = {}
 
 local has_py_mod = function(mod)
+  vim.cmd("python3 import pkgutil")
   vim.cmd("python3 import importlib")
   return vim.fn.py3eval("importlib.util.find_spec('" .. mod .. "') is not None")
 end


### PR DESCRIPTION
This is a really weird issue, import lib got changed apparently.

This is a workaround (fix?) idk. It works now for me on 3.11, and presumably 3.12.
