### PR TITLE
fix: duplicate virt text/virt text wrap

### DIFF
--- a/rplugin/python3/molten/outputbuffer.py
+++ b/rplugin/python3/molten/outputbuffer.py
@@ -131,6 +131,7 @@ class OutputBuffer:
         # images are rendered with virtual lines by image.nvim
         virtual_lines = 0
         if len(self.output.chunks) > 0:
+            x = 0
             for chunk in self.output.chunks:
                 y = lineno
                 if virtual:
@@ -138,15 +139,16 @@ class OutputBuffer:
                 chunktext, virt_lines = chunk.place(
                     buf,
                     self.options,
+                    x,
                     y,
                     shape,
                     self.canvas,
                     virtual,
                 )
                 lines_str += chunktext
-                self.nvim.out_write(f"chunktext: {chunktext}")
                 lineno += chunktext.count("\n")
                 virtual_lines += virt_lines
+                x = len(lines_str) - lines_str.rfind("\n")
 
             limit = self.options.limit_output_chars
             if limit and len(lines_str) > limit:
@@ -178,7 +180,6 @@ class OutputBuffer:
 
         win = self.nvim.current.window
         win_info = self.nvim.funcs.getwininfo(win.handle)[0]
-        # self.nvim.out_write(f"win_info: {win_info}\n")
         win_col = win_info["wincol"]
         win_row = anchor.lineno
         win_width = win_info["width"] - win_info["textoff"]
@@ -194,7 +195,6 @@ class OutputBuffer:
             win_height,
         )
         lines, _ = self.build_output_text(shape, anchor.bufno, True)
-        self.nvim.out_write(f"lines: {lines}\n")
         l = len(lines)
         if l > self.options.virt_text_max_lines:
             lines = lines[: self.options.virt_text_max_lines - 1]

--- a/rplugin/python3/molten/outputbuffer.py
+++ b/rplugin/python3/molten/outputbuffer.py
@@ -144,6 +144,7 @@ class OutputBuffer:
                     virtual,
                 )
                 lines_str += chunktext
+                self.nvim.out_write(f"chunktext: {chunktext}")
                 lineno += chunktext.count("\n")
                 virtual_lines += virt_lines
 
@@ -176,10 +177,12 @@ class OutputBuffer:
             self.virt_text_id = None
 
         win = self.nvim.current.window
-        win_col = win.col
+        win_info = self.nvim.funcs.getwininfo(win.handle)[0]
+        # self.nvim.out_write(f"win_info: {win_info}\n")
+        win_col = win_info["wincol"]
         win_row = anchor.lineno
-        win_width = win.width
-        win_height = win.height
+        win_width = win_info["width"] - win_info["textoff"]
+        win_height = win_info["height"]
 
         if self.options.virt_lines_off_by_1:
             win_row += 1
@@ -191,6 +194,7 @@ class OutputBuffer:
             win_height,
         )
         lines, _ = self.build_output_text(shape, anchor.bufno, True)
+        self.nvim.out_write(f"lines: {lines}\n")
         l = len(lines)
         if l > self.options.virt_text_max_lines:
             lines = lines[: self.options.virt_text_max_lines - 1]

--- a/rplugin/python3/molten/outputchunks.py
+++ b/rplugin/python3/molten/outputchunks.py
@@ -68,16 +68,19 @@ class TextOutputChunk(OutputChunk):
     ) -> Tuple[str, int]:
         text = clean_up_text(self.text)
         extra_lines = 0
+        ## TODO: this wrapping logic needs to happen AFTER all the chunks are combined.
         if options.wrap_output:  # count the number of extra lines this will need when wrapped
             win_width = shape[2]
             if hard_wrap:
                 lines = []
                 splits = []
                 for line in text.split("\n"):
-                    for i in range(len(line) // win_width):
-                        splits.append(line[i * win_width : win_width])
+                    index = 0
+                    for _ in range(len(line) // win_width):
+                        splits.append(line[index * win_width : (index+1)*win_width])
+                        index += 1
                     else:
-                        splits.append(line)
+                        splits.append(line[index * win_width :])
                 lines.extend(splits)
                 text = "\n".join(lines)
             else:

--- a/rplugin/python3/molten/outputchunks.py
+++ b/rplugin/python3/molten/outputchunks.py
@@ -70,7 +70,6 @@ class TextOutputChunk(OutputChunk):
     ) -> Tuple[str, int]:
         text = clean_up_text(self.text)
         extra_lines = 0
-        ## TODO: this wrapping logic needs to happen AFTER all the chunks are combined.
         if options.wrap_output:  # count the number of extra lines this will need when wrapped
             win_width = shape[2]
             if hard_wrap:

--- a/rplugin/python3/molten/outputchunks.py
+++ b/rplugin/python3/molten/outputchunks.py
@@ -32,6 +32,7 @@ class OutputChunk(ABC):
         self,
         bufnr: int,
         options: MoltenOptions,
+        col: int,
         lineno: int,
         shape: Tuple[int, int, int, int],
         canvas: Canvas,
@@ -61,7 +62,8 @@ class TextOutputChunk(OutputChunk):
         self,
         _bufnr: int,
         options: MoltenOptions,
-        _: int,
+        col: int,
+        _lineno: int,
         shape: Tuple[int, int, int, int],
         _canvas: Canvas,
         hard_wrap: bool,
@@ -76,6 +78,10 @@ class TextOutputChunk(OutputChunk):
                 splits = []
                 for line in text.split("\n"):
                     index = 0
+                    if len(line) + col > win_width:
+                        splits.append(line[: win_width - col])
+                        line = line[win_width - col :]
+
                     for _ in range(len(line) // win_width):
                         splits.append(line[index * win_width : (index+1)*win_width])
                         index += 1
@@ -135,6 +141,7 @@ class ImageOutputChunk(OutputChunk):
         self,
         bufnr: int,
         _: MoltenOptions,
+        col: int,
         lineno: int,
         _shape: Tuple[int, int, int, int],
         canvas: Canvas,


### PR DESCRIPTION
Fixes #69

Virtual text is now wrapped correctly, even when text comes in in multiple chunks.
