### PR TITLE
fix: remove orphaned cells

### DIFF
--- a/rplugin/python3/molten/__init__.py
+++ b/rplugin/python3/molten/__init__.py
@@ -701,7 +701,9 @@ class Molten:
         if len(args) > 1:
             kernel = args[1]
         else:
-            self.kernel_check(f"MoltenExportOutput{'!' if bang else ''}", path, buf, kernel_last=True)
+            self.kernel_check(
+                f"MoltenExportOutput{'!' if bang else ''}", path, buf, kernel_last=True
+            )
             return
 
         kernels = self._get_current_buf_kernels(True)

--- a/rplugin/python3/molten/code_cell.py
+++ b/rplugin/python3/molten/code_cell.py
@@ -48,6 +48,9 @@ class CodeCell:
             self.end.lineno + 1,
         )
 
+    def empty(self) -> bool:
+        return self.end <= self.begin
+
     def get_text(self, nvim: Nvim) -> str:
         assert self.begin.bufno == self.end.bufno
 


### PR DESCRIPTION
fixes #42

Now, when update interface is run, (which happens when you leave a cell) we check to see if we need to clear any cells.

Cells are cleared when their end is <= their start. when this happens, the cursor can no longer be inside of them. This caused problems with virt text output hanging around if you run some code then delete all of it without calling `:MoltenDelete`. Now this should be cleaned up automatically.
