### PR TITLE
fix: account for windows not at the top of screen

### DIFF
--- a/lua/output_window.lua
+++ b/lua/output_window.lua
@@ -7,8 +7,10 @@ local M = {}
 M.calculate_window_position = function(buf_line)
   local win = vim.api.nvim_get_current_win()
   local pos = vim.fn.screenpos(win, buf_line, 0)
+  local topline = vim.fn.line('w0')
+  local win_origin = vim.fn.screenpos(win, topline, 0)
 
-  return pos.row
+  return pos.row - (win_origin.row - 1)
 end
 
 return M


### PR DESCRIPTION
fixes #79

Slightly embarrassing bug here, output windows for text in a window who's top line wasn't at the top of the terminal would be positioned wrong. This included tab lines.
