### PR TITLE
feat: :ReevaluateAllCells command

### DIFF
--- a/rplugin/python3/molten/__init__.py
+++ b/rplugin/python3/molten/__init__.py
@@ -587,6 +587,17 @@ class Molten:
             """
             self.nvim.exec_lua(lua, async_=False)
 
+    @pynvim.command("MoltenReevaluateAll", nargs=0, sync=True)  # type: ignore
+    @nvimui  # type: ignore
+    def command_reevaluate_all(self) -> None:
+        self._initialize_if_necessary()
+
+        molten_kernels = self._get_current_buf_kernels(True)
+        assert molten_kernels is not None
+
+        for kernel in molten_kernels:
+            kernel.reevaluate_all()
+
     @pynvim.command("MoltenReevaluateCell", nargs=0, sync=True)  # type: ignore
     @nvimui  # type: ignore
     def command_evaluate_cell(self) -> None:

--- a/rplugin/python3/molten/moltenbuffer.py
+++ b/rplugin/python3/molten/moltenbuffer.py
@@ -115,6 +115,11 @@ class MoltenKernel:
 
         self._check_if_done_running()
 
+    def reevaluate_all(self) -> None:
+        for span in sorted(self.outputs.keys(), key=lambda s: s.begin):
+            code = span.get_text(self.nvim)
+            self.run_code(code, span)
+
     def reevaluate_cell(self) -> bool:
         self.selected_cell = self._get_selected_span()
         if self.selected_cell is None:


### PR DESCRIPTION
closes #25

Adds a new command, `:MoltenReevaluateAll` which reruns all existing cells for the current kernel, in the order that they appear in the file.

Known limitation, this probably doesn't work well with multiple files. It's meant to be used with notebook style cells with `:MoltenLoad`, and then quickly restore the state of your kernel with `:MoltenReevaluateAll`
