### PR TITLE
fixed markdown links

### DIFF
--- a/docs/Not-So-Quick-Start-Guide.md
+++ b/docs/Not-So-Quick-Start-Guide.md
@@ -69,7 +69,7 @@ version = "1.1.0",
 #### Python Deps
 
 **Note**: It's recommended that you install python packages in a virtual environment as outlined in
-the [venv guide](Virtual-Environments)
+the [venv guide](./Virtual-Environments.md)
 
 **Absolutely necessary python packages:**
 - [`pynvim`](https://github.com/neovim/pynvim) (for the Remote Plugin API)
@@ -88,7 +88,7 @@ the [venv guide](Virtual-Environments)
 - `plotly` and `kaleido` (for displaying Plotly figures)
     - In order to render plotly figures you might also needed `nbformat` installed in the project
     venv, unfortunately installing it in the neovim venv did not work (see [venv
-    guide](Virtual-Environments))
+    guide](./Virtual-Environments.md))
 - `pyperclip` if you want to use `molten_copy_output`
 
 #### .NET Deps

--- a/docs/Probably-Too-Quick-Start-Guide.md
+++ b/docs/Probably-Too-Quick-Start-Guide.md
@@ -6,7 +6,7 @@ In stark contrast to the other guide, this one will be really quick (I promise).
 - [`pynvim`](https://github.com/neovim/pynvim) (for the Remote Plugin API)
 - [`jupyter_client`](https://github.com/jupyter/jupyter_client) (for interacting with Jupyter)
 
-Make sure that neovim can find these (refer to [venv guide](Virtual-Environments) if you have
+Make sure that neovim can find these (refer to [venv guide](./Virtual-Environments.md) if you have
 trouble)
 
 ## Install the plugin (lazy.nvim example)
@@ -32,8 +32,8 @@ trouble)
 Congrats! You've run some code with Molten!
 
 See the README for more information about how to configure and use the plugin. See the [venv
-guide](Virtual-Environments) if you don't want to install python packages globally, and see the [not
-so quick start guide](Not-So-Quick-Start-Guide) for information about setting up image rendering.
+guide](./Virtual-Environments.md) if you don't want to install python packages globally, and see the [not
+so quick start guide](./Not-So-Quick-Start-Guide.md) for information about setting up image rendering.
 
 > [!WARNING]
 > Windows users see [the windows page](./Windows.md)


### PR DESCRIPTION
A handful of links in the docs weren't working, pointed them where they are supposed to go!