### PR TITLE
feat: auto init

### DIFF
--- a/.stylua.toml
+++ b/.stylua.toml
@@ -1,0 +1,3 @@
+column_width = 100
+indent_type = "Spaces"
+indent_width = 2

--- a/README.md
+++ b/README.md
@@ -96,6 +96,9 @@ When the `kernel` argument is specified as optional a command behaves in the fol
 - else if there is more than one active kernel for the current buffer, prompt the user for the
 kernel
 
+[some](./docs/Initialization.md) commands will prompt for a kernel when they require one but no
+kernel is attached to the buffer. This is configurable with the `molten_auto_init_behavior` option.
+
 | Command                   | Arguments             | Description                        |
 |---------------------------|-----------------------|------------------------------------|
 | `MoltenInfo`              | none                  | Show information about the state of the plugin, initialization status, available kernels, and running kernels |
@@ -161,6 +164,7 @@ variable, their values, and a brief description.
 
 | Variable                                      | Values                                                      | Description                                |
 |----------------------                         |-------------------                                          |--------------------------------------------|
+| `g:molten_auto_init_behavior`                 | `"raise"` \| (`"init"`)                                     | When set to "raise" commands which would otherwise ask for a kernel when they're run without a running kernel will instead raise an exception. Useful for other plugins that want to use `pcall` and do their own error handling |
 | `g:molten_auto_open_html_in_browser`          | `true` \| (`false`)                                         | Automatically open HTML outputs in a browser. related: `molten_open_cmd` |
 | `g:molten_auto_open_output`                   | (`true`) \| `false`                                         | Automatically open the output window when your cursor moves over a cell |
 | `g:molten_copy_output`                        | `true` \| (`false`)                                         | Copy evaluation output to clipboard automatically (requires [`pyperclip`](#requirements))|

--- a/docs/Initialization.md
+++ b/docs/Initialization.md
@@ -1,0 +1,31 @@
+# Initialization
+
+Two points. The _plugin_ is initialized on the fist action that you take that requires it. This
+fetches all of the options that molten defines, and caches their values. From this point onward,
+setting `vim.g.molten_...` will not work, and you need to use the `MoltenUpdateOption` function.
+
+This is different to what I'll call "kernel initialization", where a jupyter kernel is associated to
+the current buffer. This is done by the MoltenInit command.
+
+## :MoltenInit
+
+`:MoltenInit ["shared"] [kernel]` is the command that you run if you'd like to "initialize"
+a kernel. This associates the kernel to the current buffer.
+
+When run with no arguments, the command will list kernels that are not running, followed by kernels
+that _are_ running in other buffers. The latter are prefixed with the text `(shared)`. Selecting
+a kernel that looks like `(shared) python3` is the same as running the command `:MoltenInit shared
+python3`.
+
+## Auto Initialization
+
+Some commands require a kernel attached to the buffer to work. Of these commands, some will auto
+initialize (prompt the users as if `:MoltenInit` had been called, on selection, will initialize the
+kernel, and then after the kernel is initialized, run the original command with the new kernel).
+Here's a list of commands that will auto initialize:
+
+- `MoltenEvaluateLine`
+- `MoltenEvaluateVisual`
+- `MoltenEvaluateOperator`
+- `MoltenEvaluateArgument`
+- `MoltenImportOutput`

--- a/lua/prompt.lua
+++ b/lua/prompt.lua
@@ -1,5 +1,13 @@
 local M = {}
 
+local format_shared = function(item)
+  if item[2] then
+    return "(shared) " .. item[1]
+  else
+    return item[1]
+  end
+end
+
 ---show the MoltenInit prompt with the given kernels
 ---started as shared kernels.
 ---@param kernels table<table> list of tuples of (str, bool)
@@ -8,51 +16,55 @@ M.prompt_init = function(kernels, prompt)
   vim.schedule_wrap(function()
     vim.ui.select(kernels, {
       prompt = prompt,
-      format_item = function(item)
-        if item[2] then
-          return "(shared) " .. item[1]
-        else
-          return item[1]
-        end
-      end,
+      format_item = format_shared,
     }, function(choice)
-      if choice ~= nil then
-        vim.schedule_wrap(function()
-          if choice[2] then
-            vim.cmd("MoltenInit shared " .. choice[1])
-          else
-            vim.cmd("MoltenInit " .. choice[1])
-          end
-        end)()
+      if choice == nil then
+        return
       end
+      vim.schedule_wrap(function()
+        if choice[2] then
+          vim.cmd("MoltenInit shared " .. choice[1])
+        else
+          vim.cmd("MoltenInit " .. choice[1])
+        end
+      end)()
     end)
   end)()
 end
 
 ---show the MoltenInit prompt with the given kernels
 ---started as shared kernels.
----@param kernels table<string> list of plain kernel names
+---@param kernels table<table> list of tuples of (str, bool)
 ---@param prompt string
 ---@param command string command, with %k substituted for the selected kernel name
 M.prompt_init_and_run = function(kernels, prompt, command)
   vim.schedule_wrap(function()
     vim.ui.select(kernels, {
       prompt = prompt,
+      format_item = format_shared,
     }, function(choice)
-      if choice ~= nil then
+      if choice == nil then
+        return
+      end
+      if choice[2] then
+        vim.schedule_wrap(function()
+          vim.cmd("MoltenInit shared " .. choice[1])
+          vim.cmd(command:gsub("%%k", choice[1]))
+        end)()
+      else
         vim.api.nvim_create_autocmd("User", {
           pattern = "MoltenKernelReady",
           once = true,
           callback = function(e)
-            vim.cmd(command:gsub("%%k", e.data))
+            vim.cmd(command:gsub("%%k", e.data.kernel_id))
           end,
         })
         vim.schedule_wrap(function()
-          vim.cmd("MoltenInit " .. choice)
+          vim.cmd("MoltenInit " .. choice[1])
         end)()
       end
-    end)
-  end)()
+    end) -- ui select
+  end)() -- vim.schedule_wrap
 end
 
 ---prompt the user for a kernel, and then run the command with that kernel. %k in the command means

--- a/lua/prompt.lua
+++ b/lua/prompt.lua
@@ -29,19 +29,45 @@ M.prompt_init = function(kernels, prompt)
   end)()
 end
 
+---show the MoltenInit prompt with the given kernels
+---started as shared kernels.
+---@param kernels table<string> list of plain kernel names
+---@param prompt string
+---@param command string command, with %k substituted for the selected kernel name
+M.prompt_init_and_run = function(kernels, prompt, command)
+  vim.schedule_wrap(function()
+    vim.ui.select(kernels, {
+      prompt = prompt,
+    }, function(choice)
+      if choice ~= nil then
+        vim.api.nvim_create_autocmd("User", {
+          pattern = "MoltenKernelReady",
+          once = true,
+          callback = function(e)
+            vim.cmd(command:gsub("%%k", e.data))
+          end,
+        })
+        vim.schedule_wrap(function()
+          vim.cmd("MoltenInit " .. choice)
+        end)()
+      end
+    end)
+  end)()
+end
+
 ---prompt the user for a kernel, and then run the command with that kernel. %k in the command means
 ---the kernel name will be substituted in.
 ---@param kernels table<string> list of kernels
 ---@param prompt string
 ---@param command string command, with %k substituted for the selected kernel name
-M.select_and_run = function (kernels, prompt, command)
+M.select_and_run = function(kernels, prompt, command)
   vim.schedule_wrap(function()
     vim.ui.select(kernels, {
       prompt = prompt,
     }, function(choice)
       if choice ~= nil then
         vim.schedule_wrap(function()
-            vim.cmd(command:gsub("%%k", choice))
+          vim.cmd(command:gsub("%%k", choice))
         end)()
       end
     end)

--- a/rplugin/python3/molten/moltenbuffer.py
+++ b/rplugin/python3/molten/moltenbuffer.py
@@ -73,9 +73,11 @@ class MoltenKernel:
 
         self.options = options
 
-    def _doautocmd(self, autocmd: str) -> None:
+    def _doautocmd(self, autocmd: str, opts: Dict = {}) -> None:
         assert " " not in autocmd
-        self.nvim.command(f"doautocmd User {autocmd}")
+        opts["pattern"] = autocmd
+        self.nvim.api.exec_autocmds("User", opts)
+        # self.nvim.command(f"doautocmd User {autocmd}")
 
     def add_nvim_buffer(self, buffer: Buffer) -> None:
         self.buffers.append(buffer)
@@ -197,7 +199,15 @@ class MoltenKernel:
         if did_stuff:
             self.update_interface()
         if not was_ready and self.runtime.is_ready():
-            notify_info(self.nvim, f"Kernel '{self.runtime.kernel_name}' is ready.")
+            self._doautocmd(
+                "MoltenKernelReady",
+                opts={
+                    "data": self.kernel_id,
+                },
+            )
+            notify_info(
+                self.nvim, f"Kernel '{self.runtime.kernel_name}' (id: {self.kernel_id}) is ready."
+            )
 
     def enter_output(self) -> None:
         if self.selected_cell is not None:

--- a/rplugin/python3/molten/moltenbuffer.py
+++ b/rplugin/python3/molten/moltenbuffer.py
@@ -202,7 +202,9 @@ class MoltenKernel:
             self._doautocmd(
                 "MoltenKernelReady",
                 opts={
-                    "data": self.kernel_id,
+                    "data": {
+                        "kernel_id": self.kernel_id,
+                    }
                 },
             )
             notify_info(

--- a/rplugin/python3/molten/options.py
+++ b/rplugin/python3/molten/options.py
@@ -63,7 +63,7 @@ class MoltenOptions:
         self.hl = HL()
         # fmt: off
         CONFIG_VARS = [
-            ("molten_auto_init_behavior", "raise"), # "raise" or "init"
+            ("molten_auto_init_behavior", "init"), # "raise" or "init"
             ("molten_auto_open_html_in_browser", False),
             ("molten_auto_open_output", True),
             ("molten_copy_output", False),

--- a/rplugin/python3/molten/options.py
+++ b/rplugin/python3/molten/options.py
@@ -31,8 +31,9 @@ class HL:
 
 
 class MoltenOptions:
-    auto_open_output: bool
+    auto_init_behavior: str
     auto_open_html_in_browser: bool
+    auto_open_output: bool
     copy_output: bool
     enter_output_behavior: str
     image_provider: str
@@ -62,6 +63,7 @@ class MoltenOptions:
         self.hl = HL()
         # fmt: off
         CONFIG_VARS = [
+            ("molten_auto_init_behavior", "raise"), # "raise" or "init"
             ("molten_auto_open_html_in_browser", False),
             ("molten_auto_open_output", True),
             ("molten_copy_output", False),


### PR DESCRIPTION
will close #61

- adds stylua.toml
- adds "MoltenKernelReady" User autocommand, fired when a kernel is ready, with the assigned kernel id.
- adds auto_init_behavior option, either "raise" or "init"

when set to "init", running a command that would otherwise error b/c there is no running kernel will instead prompt the user to select a kernel that they'd like to initialize for the buffer.

TODO: 
- [x] kernel list doesn't include shared kernels yet
- [x] track down all the cases where kernel_check is used vs. get_current_buf_kernels, b/c they currently have different behavior.
- [x] testing (not exhaustive, but I'm confident it's mostly working)
- [x] documenting
