### PR TITLE
fix image nvim provider config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ variable, their values, and a brief description.
 | `g:molten_auto_open_output`                   | (`true`) \| `false`                                         | Automatically open the output window when your cursor moves over a cell |
 | `g:molten_copy_output`                        | `true` \| (`false`)                                         | Copy evaluation output to clipboard automatically (requires [`pyperclip`](#requirements))|
 | `g:molten_enter_output_behavior`              | (`"open_then_enter"`) \| `"open_and_enter"` \| `"no_open`   | The behavior of [MoltenEnterOutput](#moltenenteroutput) |
-| `g:molten_image_provider`                     | (`"none"`) \| `"image_nvim"`                                | How image are displayed |
+| `g:molten_image_provider`                     | (`"none"`) \| `"image.nvim"`                                | How image are displayed |
 | `g:molten_open_cmd`                           | (`nil`) \| Any command                                      | Defaults to `xdg-open` on Linux, `open` on Darwin, and `start` on Windows. But you can override it to whatever you want. The command is called like: `subprocess.run([open_cmd, filepath])` |
 | `g:molten_output_crop_border`                 | (`true`) \| `false`                                         | 'crops' the bottom border of the output window when it would otherwise just sit at the bottom of the screen |
 | `g:molten_output_show_more`                   | `true` \| (`false`)                                         | When the window can't display the entire contents of the output buffer, shows the number of extra lines in the window footer (requires nvim 10.0+ and a window border) |


### PR DESCRIPTION
This should fix #21 

Example lazy configuration:

```lua
return {
    {
        "benlubas/molten-nvim",
        version = "^1.0.0", -- use version <2.0.0 to avoid breaking changes
        build = ":UpdateRemotePlugins",
        dependencies = { "3rd/image.nvim" },
        init = function()
            -- this is an example, not a default. Please see the readme for more configuration options
            vim.g.molten_image_provider = "image.nvim"
        end,
    },
}
```