### PR TITLE
fix: Add a `__repr__` method for `CodeCell` and `DynamicPosition`

### DIFF
--- a/rplugin/python3/molten/code_cell.py
+++ b/rplugin/python3/molten/code_cell.py
@@ -39,6 +39,9 @@ class CodeCell:
     def __str__(self) -> str:
         return f"CodeCell({self.begin}, {self.end})"
 
+    def __repr__(self) -> str:
+        return f"CodeCell(begin={self.begin}, end={self.end})"
+
     def clear_interface(self, highlight_namespace):
         """Clear the highlight of the code cell"""
         self.nvim.funcs.nvim_buf_clear_namespace(

--- a/rplugin/python3/molten/position.py
+++ b/rplugin/python3/molten/position.py
@@ -63,6 +63,9 @@ class DynamicPosition(Position):
     def __str__(self) -> str:
         return f"DynamicPosition({self.bufno}, {self.lineno}, {self.colno})"
 
+    def __repr__(self) -> str:
+        return f"DynamicPosition(bufno={self.bufno}, lineno={self.lineno}, colno={self.colno})"
+
     def _get_pos(self) -> List[int]:
         out = self.nvim.funcs.nvim_buf_get_extmark_by_id(
             self.bufno, self.extmark_namespace, self.extmark_id, {}


### PR DESCRIPTION
Closes #115. 

Let me know if there is a particular formatting you'd like for a repr, or if it should just use the `__str__` implementation.