### PR TITLE
fix: don't require pillow unless it's used

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ window (or both)
   - `plotly` and `kaleido` (for displaying Plotly figures)
   - `pyperclip` if you want to use `molten_copy_output`
   - `nbformat` for importing and exporting output to jupyter notebooks files
+  - `pillow` for opening images with `:MoltenImagePopup`
 
 You can run `:checkhealth` to see what you have installed.
 

--- a/lua/molten/health.lua
+++ b/lua/molten/health.lua
@@ -45,6 +45,7 @@ M.check = function()
   py_mod_check("kaleido", "kaleido", false)
   py_mod_check("pyperclip", "pyperclip", false)
   py_mod_check("nbformat", "nbformat", false)
+  py_mod_check("PIL", "pillow", false)
 end
 
 return M

--- a/rplugin/python3/molten/moltenbuffer.py
+++ b/rplugin/python3/molten/moltenbuffer.py
@@ -3,7 +3,6 @@ from datetime import datetime
 from typing import IO, Callable, List, Optional, Dict, Tuple
 from queue import Queue
 import hashlib
-from PIL import Image
 
 from pynvim import Nvim
 from pynvim.api import Buffer
@@ -146,10 +145,16 @@ class MoltenKernel:
         for chunk in output.chunks:
             if isinstance(chunk, ImageOutputChunk):
                 try:
+                    from PIL import Image
                     img = Image.open(chunk.img_path)
                     img.show(f"[{output.execution_count}] Molten Image")
                     if not silent:
                         notify_info(self.nvim, "Opened image popup")
+                except ModuleNotFoundError:
+                    if not silent:
+                        notify_error(
+                            self.nvim, "Failed to open image becuase module `PIL` was not found"
+                        )
                 except:
                     if not silent:
                         notify_error(


### PR DESCRIPTION
Fixes another import issue. Where pillow should not be required unless the image popup command is used
