### PR TITLE
fix: correct execution time for multiple cells

### DIFF
--- a/rplugin/python3/molten/outputbuffer.py
+++ b/rplugin/python3/molten/outputbuffer.py
@@ -70,7 +70,7 @@ class OutputBuffer:
         else:
             old = ""
 
-        if not output.old and self.options.output_show_exec_time:
+        if not output.old and self.options.output_show_exec_time and output.start_time:
             start = output.start_time
             end = output.end_time if output.end_time is not None else datetime.now()
             diff = end - start

--- a/rplugin/python3/molten/outputchunks.py
+++ b/rplugin/python3/molten/outputchunks.py
@@ -179,8 +179,8 @@ class Output:
     status: OutputStatus
     success: bool
     old: bool
-    start_time: datetime
-    end_time: datetime
+    start_time: datetime | None
+    end_time: datetime | None
 
     _should_clear: bool
 
@@ -191,7 +191,7 @@ class Output:
         self.success = True
         self.old = False
 
-        self.start_time = datetime.now()
+        self.start_time = None
         self.end_time = None
 
         self._should_clear = False

--- a/rplugin/python3/molten/runtime.py
+++ b/rplugin/python3/molten/runtime.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import Optional, Tuple, List, Dict, Generator, IO, Any
 from enum import Enum
 from contextlib import contextmanager
@@ -142,6 +143,7 @@ class JupyterRuntime:
                     return False
                 if output.status == OutputStatus.HOLD:
                     output.status = OutputStatus.RUNNING
+                    output.start_time = datetime.now()
                 elif output.status == OutputStatus.RUNNING:
                     output.status = OutputStatus.DONE
                 else:


### PR DESCRIPTION
when running multiple cells, execution time would start counting up while the second cell is waiting for the first cell to finish
