### PR TITLE
fix: image loss on refresh and stop refreshes when done computing

### DIFF
--- a/rplugin/python3/molten/moltenbuffer.py
+++ b/rplugin/python3/molten/moltenbuffer.py
@@ -228,7 +228,7 @@ class MoltenKernel:
 
                 output.end_time = datetime.now()
 
-        if self.options.output_show_exec_time or did_stuff:
+        if did_stuff or (self.options.output_show_exec_time and starting_status != OutputStatus.DONE):
             self.update_interface()
 
         if not was_ready and self.runtime.is_ready():

--- a/rplugin/python3/molten/moltenbuffer.py
+++ b/rplugin/python3/molten/moltenbuffer.py
@@ -215,6 +215,7 @@ class MoltenKernel:
         was_ready = self.runtime.is_ready()
         if self.current_output is None or not self.current_output in self.outputs:
             did_stuff = self.runtime.tick(None)
+            starting_status = OutputStatus.HOLD
         else:
             output = self.outputs[self.current_output].output
             starting_status = output.status

--- a/rplugin/python3/molten/outputbuffer.py
+++ b/rplugin/python3/molten/outputbuffer.py
@@ -292,6 +292,7 @@ class OutputBuffer:
 
         # Clear buffer:
         self.nvim.funcs.deletebufline(self.display_buf.number, 1, "$")
+        self.canvas.clear()
 
         sign_col_width = 0
         text_off = self.nvim.funcs.getwininfo(win.handle)[0]["textoff"]


### PR DESCRIPTION
# Bugfix
* On output buffer refresh, the output buffer was cleared, but images were not re-rendered (missing matching canvas.clear)
* If execution time is shown, the output window never stopped refreshing even after computations were done (missing check of starting_status)