### PR TITLE
fix: match lines added by image.nvim

### DIFF
--- a/rplugin/python3/molten/outputbuffer.py
+++ b/rplugin/python3/molten/outputbuffer.py
@@ -153,7 +153,7 @@ class OutputBuffer:
             )
 
     def build_output_text(self, shape, buf: int, virtual: bool) -> Tuple[List[str], int]:
-        lineno = 0
+        lineno = 1 # we add a status line at the top in the end
         lines_str = ""
         # images are rendered with virtual lines by image.nvim
         virtual_lines = 0

--- a/rplugin/python3/molten/outputchunks.py
+++ b/rplugin/python3/molten/outputchunks.py
@@ -160,11 +160,13 @@ class ImageOutputChunk(OutputChunk):
             self.img_path,
             f"{'virt-' if virtual else ''}{self.img_path}",
             0,
-            lineno + 1,
+            lineno,
             bufnr,
             winnr,
         )
-        return "", canvas.img_size(self.img_identifier)["height"]
+        # images are rendered into virtual lines following the current line,
+        # which also needs to exist as the extmark is placed there
+        return " \n", canvas.img_size(self.img_identifier)["height"]
 
 
 class OutputStatus(Enum):


### PR DESCRIPTION
## Bugfix

An insufficient number of lines was added to the output buffer for images to place their extmark and virtual lines. This commit always adds one space character and one newline for each image, so that the extmark line sits in front of the image, which is fully placed into virtual lines by `image.nvim`.

I also modified the `lineno` to start at 1 in order to account for the leading status line, it would be good to check if this makes sense to you, otherwise I could not make sense of the +1 specifically for images.