### PR TITLE
docs: give example of blank new notebook command in notebook-setup.md

### DIFF
--- a/docs/Notebook-Setup.md
+++ b/docs/Notebook-Setup.md
@@ -411,6 +411,71 @@ vim.api.nvim_create_autocmd("BufEnter", {
 })
 ```
 
+#### Creating new notebooks
+
+Since Jupytext needs a valid notebook file to convert, creating a blank new notebook is not as easy as making an empty buffer and loading it up.
+
+To simplify this workflow, you can define a vim user command to create an empty, but valid, notebook file and open it:
+
+```lua
+-- Provide a command to create a blank new Python notebook
+-- note: the metadata is needed for Jupytext to understand how to parse the notebook.
+-- if you use another language than Python, you should change it in the template.
+local default_notebook = [[
+  {
+    "cells": [
+     {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        ""
+      ]
+     }
+    ],
+    "metadata": {
+     "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+     },
+     "language_info": {
+      "codemirror_mode": {
+        "name": "ipython"
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3"
+     }
+    },
+    "nbformat": 4,
+    "nbformat_minor": 5
+  }
+]]
+
+local function new_notebook(filename)
+  local path = filename .. ".ipynb"
+  local file = io.open(path, "w")
+  if file then
+    file:write(default_notebook)
+    file:close()
+    vim.cmd("edit " .. path)
+  else
+    print("Error: Could not open new notebook file for writing.")
+  end
+end
+
+vim.api.nvim_create_user_command('NewNotebook', function(opts)
+  new_notebook(opts.args)
+end, {
+  nargs = 1,
+  complete = 'file'
+})
+```
+
+You can then use `:NewNotebook folder/notebook_name` to start a new notebook from scratch!
+
 ## Compromises
 
 Compared to Jupyter-lab:


### PR DESCRIPTION
Closes https://github.com/benlubas/molten-nvim/issues/213

Provide an example of a `:NewNotebook` user command to create valid, blank python notebooks from scratch.