### PR TITLE
fix: reevaluate not working

### DIFF
--- a/rplugin/python3/molten/ipynb.py
+++ b/rplugin/python3/molten/ipynb.py
@@ -57,9 +57,6 @@ def import_outputs(nvim: Nvim, kernel: MoltenKernel, filepath: str):
                 continue
 
             if nb_line >= len(nb_contents) - 1:
-                if len(cell["outputs"]) == 0:
-                    buf_line += 1
-                    break
                 # we're done. This is a match, we'll create the output
                 output = Output(cell["execution_count"])
                 output.old = True


### PR DESCRIPTION
Code cells that do not produce output, e.g. python import statements are not considered as code cells in the current buffer. As a consequence reevaluate cell and all is not working