### PR TITLE
fix(import): create molten cells for code that runs with no output

### DIFF
--- a/rplugin/python3/molten/ipynb.py
+++ b/rplugin/python3/molten/ipynb.py
@@ -57,13 +57,15 @@ def import_outputs(nvim: Nvim, kernel: MoltenKernel, filepath: str):
                 continue
 
             if nb_line >= len(nb_contents) - 1:
-                if len(cell["outputs"]) == 0:
-                    buf_line += 1
-                    break
                 # we're done. This is a match, we'll create the output
                 output = Output(cell["execution_count"])
                 output.old = True
                 output.success = True
+                if output.execution_count:
+                    output.status = OutputStatus.DONE
+                else:
+                    output.status = OutputStatus.NEW
+
                 for output_data in cell["outputs"]:
                     m_chunk, success = handle_output_types(nvim, output_data.get("output_type"), kernel, output_data)
                     output.chunks.append(m_chunk)
@@ -97,7 +99,6 @@ def import_outputs(nvim: Nvim, kernel: MoltenKernel, filepath: str):
                 kernel.extmark_namespace,
                 kernel.options,
             )
-            output.status = OutputStatus.DONE
             kernel.outputs[span].output = output
             kernel.update_interface()
         else:

--- a/rplugin/python3/molten/outputchunks.py
+++ b/rplugin/python3/molten/outputchunks.py
@@ -61,7 +61,7 @@ class TextOutputChunk(OutputChunk):
         self.output_type = "display_data"
 
     def __repr__(self) -> str:
-        return f"TextOutputChunk(\"{self.text}\")"
+        return f'TextOutputChunk("{self.text}")'
 
     def place(
         self,
@@ -169,8 +169,13 @@ class ImageOutputChunk(OutputChunk):
 
 class OutputStatus(Enum):
     HOLD = 0
+    """Waiting to run this cell"""
     RUNNING = 1
+    """Currently running, waiting for code to finish running"""
     DONE = 2
+    """Code has already been run"""
+    NEW = 3
+    """Cell was created, nothing run, no output"""
 
 
 class Output:
@@ -201,15 +206,16 @@ class Output:
         character, this is b/c outputs before a \r aren't shown, and so, should be deleted"""
         if (
             len(self.chunks) >= 2
-                and isinstance((c1 := self.chunks[-2]), TextOutputChunk)
-                and isinstance((c2 := self.chunks[-1]), TextOutputChunk)
+            and isinstance((c1 := self.chunks[-2]), TextOutputChunk)
+            and isinstance((c2 := self.chunks[-1]), TextOutputChunk)
         ):
             c1.text += c2.text
             c1.text = "\n".join([re.sub(r".*\r", "", x) for x in c1.text.split("\n")[:-1]])
-            c1.jupyter_data = { "text/plain": c1.text }
+            c1.jupyter_data = {"text/plain": c1.text}
             self.chunks.pop()
         elif len(self.chunks) > 0 and isinstance((c1 := self.chunks[0]), TextOutputChunk):
             c1.text = "\n".join([re.sub(r".*\r", "", x) for x in c1.text.split("\n")[:-1]])
+
 
 def to_outputchunk(
     nvim: Nvim,


### PR DESCRIPTION
supersedes #221 

Code cells that do not produce output, e.g. python import statements are not considered as code cells when importing outputs.

As a consequence `:MoltenReevaluateCell/All` fails unexpectedly after importing output from an ipynb file.

---

The fix for this issue comes with a new feature. There's a new output status `NEW`. New cells have no output, and have never been run (execution count == null), currently they're only created by the `:MoltenImportOutput` command, and they show `Out[_]: Never Run` in virtual text or the floating window.

The import script no longer breaks on cells that have a 0 length output list, and instead _will_ create a molten cell, marked either `DONE` or `NEW` based on the exec count.

If someone has a more concise or otherwise better way to communicate `Never Run` I'd love suggestions. I personally don't like the text `Never Run` but need something to be there.