### PR TITLE
fix: add padding to base64 strings

### DIFF
--- a/rplugin/python3/molten/outputchunks.py
+++ b/rplugin/python3/molten/outputchunks.py
@@ -235,7 +235,9 @@ def to_outputchunk(
         import base64
 
         with alloc_file(extension, "wb") as (path, file):
-            file.write(base64.b64decode(str(imgdata)))
+            s = str(imgdata)
+            s += "=" * ((4 - len(s) % 4) % 4)
+            file.write(base64.b64decode(s))
         return _to_image_chunk(path)
 
     def _from_image_svgxml(svg: str) -> OutputChunk:


### PR DESCRIPTION
I have been playing around with the new R kernel Ark (https://github.com/posit-dev/ark).

Some kernels don't add padding to their base64 encoded image responses, so we can add it here. This doesn't conflict with kernels that do add padding because `base64.b64decode` silently truncates extra padding (unless `validate=True`). With this PR is now works for Ark:

![image](https://github.com/user-attachments/assets/eee682cf-5336-4060-9427-364c54a1c5b4)

and ipython:

![image](https://github.com/user-attachments/assets/71b79f22-9372-40f3-9b03-a8c622c53592)
