### PR TITLE
docs: Enhance/Refactor detecting kernel which name is same as venv 

### DIFF
--- a/docs/Notebook-Setup.md
+++ b/docs/Notebook-Setup.md
@@ -16,12 +16,12 @@ other plugins that I don't use but will mention at the bottom.
 
 ## The promise:
 
-\> your friend sends you a jupyter notebook file  
-\> `nvim friends_file.ipynb`  
-\> you see a markdown representation of the notebook, including code outputs and images  
+\> your friend sends you a jupyter notebook file
+\> `nvim friends_file.ipynb`
+\> you see a markdown representation of the notebook, including code outputs and images
 \> you edit the notebook, with LSP autocomplete, and format the code cells before running
-your new code, and all the cells below it, watching each cell output update as they run  
-\> `:wq`  
+your new code, and all the cells below it, watching each cell output update as they run
+\> `:wq`
 \> You send the `.ipynb` file, complete with your changes and the output of the code you
 ran, back to your friend
 
@@ -104,7 +104,7 @@ The neovim plugin [quarto-nvim](https://github.com/quarto-dev/quarto-nvim) provi
 
 <details>
   <summary>Sample configuration for quarto-nvim</summary>
-  
+
 ```lua
 local quarto = require("quarto")
 quarto.setup({
@@ -284,7 +284,7 @@ local imb = function(e) -- init molten buffer
         local ok, kernel_name = pcall(try_kernel_name)
         if not ok or not vim.tbl_contains(kernels, kernel_name) then
             kernel_name = nil
-            local venv = os.getenv("VIRTUAL_ENV")
+            local venv = os.getenv("VIRTUAL_ENV") or os.getenv("CONDA_PREFIX")
             if venv ~= nil then
                 kernel_name = string.match(venv, "/.+/(.+)")
             end

--- a/docs/Virtual-Environments.md
+++ b/docs/Virtual-Environments.md
@@ -13,6 +13,9 @@ wrapper](https://gist.github.com/benlubas/5b5e38ae27d9bb8b5c756d8371e238e6). I w
 recommend a wrapper script of some kind if you are a python dev. If you're just installing these
 deps to use Molten with a non-python kernel, you can skip the wrapper without much worry.
 
+If you are using Anaconda or Miniconda as virtual environment manager, remind that your environment
+path is `CONDA_PREFIX` instead of `VIRTUAL_ENV`.
+
 ## Create a Virtual Environment
 
 We'll create a virtual environment called `neovim` that will contain all of our Molten (and other
@@ -72,7 +75,7 @@ initialize the correct kernel.
 
 ```lua
 vim.keymap.set("n", "<localleader>ip", function()
-  local venv = os.getenv("VIRTUAL_ENV")
+  local venv = os.getenv("VIRTUAL_ENV") or os.getenv("CONDA_PREFIX"):
   if venv ~= nil then
     -- in the form of /home/benlubas/.virtualenvs/VENV_NAME
     venv = string.match(venv, "/.+/(.+)")


### PR DESCRIPTION
> Just for suggestion. From what I've observed, Molten use kernel name as a kernel ID. Therefore it display the default name of kernel in every environments, (python3 in conda) which make user confused. I refactor it based on the assumption that user [installed a kernel inside of the project](https://github.com/benlubas/molten-nvim/blob/92b2599ef813b188391d5f00f5f94ce22ecd2598/docs/Virtual-Environments.md#install-the-kernel-in-a-project-virtual-environment)

Whether the user installs ipykernel or not, this logic searches for a kernel with the same name as the venv.  
If not, it asks the user to select the kernel to connect to.

This PR intended following details:
- `try_env_name`: Turn getting env path logic into a function, enhance reusability.
- Slight changes of regex, ensure to find last dir/file of kernel_name.
- Give priority to `env_ok` at the condition statement, check if virtual env turned on. If so, load the kernel which named same with virtual environment first.


https://github.com/user-attachments/assets/7f23e058-ba65-4f98-aaaa-53a56bd3e331

