### PR TITLE
docs: remove typo that leads to error

### DIFF
--- a/docs/Virtual-Environments.md
+++ b/docs/Virtual-Environments.md
@@ -72,7 +72,7 @@ initialize the correct kernel.
 
 ```lua
 vim.keymap.set("n", "<localleader>ip", function()
-  local venv = os.getenv("VIRTUAL_ENV") or os.getenv("CONDA_PREFIX"):
+  local venv = os.getenv("VIRTUAL_ENV") or os.getenv("CONDA_PREFIX")
   if venv ~= nil then
     -- in the form of /home/benlubas/.virtualenvs/VENV_NAME
     venv = string.match(venv, "/.+/(.+)")


### PR DESCRIPTION
There's a random colon that leads to an error