### PR TITLE
[Update Documentation]: Add Instructions for Configuring Plugin via Nixvim

### DIFF
--- a/docs/NixOS.md
+++ b/docs/NixOS.md
@@ -51,20 +51,6 @@ so:
 ```nix
   # home.nix or wherever you configure neovim
   { pkgs, ... }:
-  let
-    # the vimPlugins.molten-nvim package has not been merged into nixpkgs yet but for now you can use this
-    molten-nvim = pkgs.callPackage pkgs.vimUtils.buildVimPlugin {
-      pname = "molten-nvim";
-      version = "2023-10-21";
-      src = fetchFromGitHub {
-        owner = "benlubas";
-        repo = "molten-nvim";
-        rev = "f9c28efc13f7a262e27669b984f3839ff5c50c32";
-        sha256 = "1r8xf3jphgml0pax34p50d67rglnq5mazdlmma1jnfkm67acxaac";
-      };
-      meta.homepage = "https://github.com/benlubas/molten-nvim/";
-    };
-  in {
     # ... other config
     programs.neovim = {
       # whatever other neovim configuration you have

--- a/docs/NixOS.md
+++ b/docs/NixOS.md
@@ -7,6 +7,42 @@ your neovim plugins with lazy.
 These setups include setup for `image.nvim`. If you don't need image rendering, you can exclude the
 lines marked `# for image rendering`.
 
+## Nixvim Installation
+
+If you manage your Neovim plugins through [Nixvim](https://nix-community.github.io/nixvim/), you can easily configure [molten.nvim](https://nix-community.github.io/nixvim/plugins/molten/index.html#molten) by adding it to your setup as shown below:
+
+```nix
+programs.nixvim = {
+  plugins.molten = {
+    enable = true;
+
+    # Configuration settings for molten.nvim. More examples at https://github.com/nix-community/nixvim/blob/main/plugins/by-name/molten/default.nix#L191
+    settings = {
+      auto_image_popup = false;
+      auto_init_behavior = "init";
+      auto_open_html_in_browser = false;
+      auto_open_output = true;
+      cover_empty_lines = false;
+      copy_output = false;
+      enter_output_behavior = "open_then_enter";
+      image_provider = "none";
+      output_crop_border = true;
+      output_virt_lines = false;
+      output_win_border = [ "" "━" "" "" ];
+      output_win_hide_on_leave = true;
+      output_win_max_height = 15;
+      output_win_max_width = 80;
+      save_path.__raw = "vim.fn.stdpath('data')..'/molten'";
+      tick_rate = 500;
+      use_border_highlights = false;
+      limit_output_chars = 10000;
+      wrap_output = false;
+    };
+  };
+};
+
+```
+
 ## NixOS Home Manager Installation
 
 If you use home manager and have configure Neovim through it, you can set up the dependencies like


### PR DESCRIPTION
1. Nixvim Configuration Guide: Added detailed instructions for configuring molten.nvim through Nixvim. This section guides users on enabling the plugin and setting common configuration options using Nix. The new guide includes example settings, which can be further customized based on user needs. Documentation for additional options is referenced in the Nixvim documentation.

2. Home Manager Installation Update: Updated the Home Manager installation instructions to reflect that molten.nvim is now available in Nixpkgs. This removes the need to build the plugin from source, simplifying installation and setup.