### PR TITLE
fix: check if float window is valid before closing

### DIFF
--- a/rplugin/python3/molten/outputbuffer.py
+++ b/rplugin/python3/molten/outputbuffer.py
@@ -125,7 +125,8 @@ class OutputBuffer:
 
     def clear_float_win(self) -> None:
         if self.display_win is not None:
-            self.nvim.funcs.nvim_win_close(self.display_win, True)
+            if self.display_win.valid:
+                self.nvim.funcs.nvim_win_close(self.display_win, True)
             self.display_win = None
             redraw = False
             for chunk in self.output.chunks:


### PR DESCRIPTION
Sometimes users can close the float window (result window) manually or via autocmds (e.g. I set an autocmd to close the output window automatically on WinScrolled event), so we have to check if the window is valid before closing in `clear_float_win()` to avoid errors.