### PR TITLE
fix: replace deprecated nvim_err_writeln

### DIFF
--- a/lua/load_image_nvim.lua
+++ b/lua/load_image_nvim.lua
@@ -2,7 +2,7 @@
 local ok, image = pcall(require, "image")
 
 if not ok then
-  vim.api.nvim_echo({ { "[Molten] `wezterm.nvim` not found" } }, true, { err = true })
+  vim.api.nvim_echo({ { "[Molten] `image.nvim` not found" } }, true, { err = true })
   return
 end
 

--- a/lua/load_image_nvim.lua
+++ b/lua/load_image_nvim.lua
@@ -2,7 +2,7 @@
 local ok, image = pcall(require, "image")
 
 if not ok then
-  vim.api.nvim_err_writeln("[Molten] `image.nvim` not found")
+  vim.api.nvim_echo({ { "[Molten] `wezterm.nvim` not found" } }, true, { err = true })
   return
 end
 

--- a/lua/load_wezterm_nvim.lua
+++ b/lua/load_wezterm_nvim.lua
@@ -1,7 +1,7 @@
 -- loads the wezterm.nvim plugin and exposes methods to the python remote plugin
 local ok, wezterm = pcall(require, "wezterm")
 if not ok then
-  vim.api.nvim_err_writeln("[Molten] `wezterm.nvim` not found")
+  vim.api.nvim_echo({ { "[Molten] `wezterm.nvim` not found" } }, true, { err = true })
   return
 end
 
@@ -21,7 +21,8 @@ local validate_split_dir = function(direction)
   --if direction not in accepted_dirs, return "bottom" else return direction
   if not vim.tbl_contains(accepted_dirs, direction) then
     vim.notify(
-      "[Molten] 'molten_split_dir' must be one of 'top', 'bottom', 'left', or 'right', defaulting to 'right'"
+      "[Molten] 'molten_split_dir' must be one of 'top', 'bottom', 'left', or 'right', defaulting to 'right'",
+      3
     )
     return "right"
   end
@@ -35,7 +36,8 @@ end
 local validate_split_size = function(size)
   if size == nil or size < 0 or size > 100 then
     vim.notify(
-      "[Molten] 'molten_split_size' must be a number between 0 and 100, defaulting to a 40% split."
+      "[Molten] 'molten_split_size' must be a number between 0 and 100, defaulting to a 40% split.",
+      3
     )
     return 40
   end

--- a/lua/load_wezterm_nvim.lua
+++ b/lua/load_wezterm_nvim.lua
@@ -22,7 +22,7 @@ local validate_split_dir = function(direction)
   if not vim.tbl_contains(accepted_dirs, direction) then
     vim.notify(
       "[Molten] 'molten_split_dir' must be one of 'top', 'bottom', 'left', or 'right', defaulting to 'right'",
-      3
+      vim.log.levels.WARN()
     )
     return "right"
   end
@@ -37,7 +37,7 @@ local validate_split_size = function(size)
   if size == nil or size < 0 or size > 100 then
     vim.notify(
       "[Molten] 'molten_split_size' must be a number between 0 and 100, defaulting to a 40% split.",
-      3
+      vim.log.levels.WARN()
     )
     return 40
   end

--- a/lua/load_wezterm_nvim.lua
+++ b/lua/load_wezterm_nvim.lua
@@ -22,7 +22,7 @@ local validate_split_dir = function(direction)
   if not vim.tbl_contains(accepted_dirs, direction) then
     vim.notify(
       "[Molten] 'molten_split_dir' must be one of 'top', 'bottom', 'left', or 'right', defaulting to 'right'",
-      vim.log.levels.WARN()
+      vim.log.levels.WARN
     )
     return "right"
   end
@@ -37,7 +37,7 @@ local validate_split_size = function(size)
   if size == nil or size < 0 or size > 100 then
     vim.notify(
       "[Molten] 'molten_split_size' must be a number between 0 and 100, defaulting to a 40% split.",
-      vim.log.levels.WARN()
+      vim.log.levels.WARN
     )
     return 40
   end


### PR DESCRIPTION
Updated my nightly neovim(0.11) this morning and noticed some discussion about the deprecation of nvim_notify (not vim.notify) and write_ln. It reminded me that I had used that here and thought I would come fix it up. Noticed it was also used in the load_image file as well so I modified that one as well. 

This is the recommended replacement that I read in the nvim [deprecation docs suggests](https://github.com/neovim/neovim/blob/master/runtime/doc/deprecated.txt) nvim_echo(). Also noticed a couple of calls to vim.notif() that didn't have the proper log level suggested. They were defaulting to error when they should have been warning level.