### PR TITLE
fix: improved virt_lines_off_by_1 behavior. if code block is on last line do not offset by 1 to ensure virtual text is visible.

### DIFF
--- a/rplugin/python3/molten/outputbuffer.py
+++ b/rplugin/python3/molten/outputbuffer.py
@@ -223,11 +223,12 @@ class OutputBuffer:
         win_row = anchor.lineno + offset
         win_width = win_info["width"] - win_info["textoff"]
         win_height = win_info["height"]
+        last = self.nvim.funcs.line("$")
 
-        if self.options.virt_lines_off_by_1:
+        if self.options.virt_lines_off_by_1 and win_row < last - 1:
             win_row += 1
 
-        if win_row > (last := self.nvim.funcs.line("$")):
+        if win_row > last:
             win_row = last
 
         shape = (


### PR DESCRIPTION
This pull request resolves a minor bug where virtual text is not visible when block code is on last line of buffer. I added a check for this condition.

Results:
![image](https://github.com/user-attachments/assets/b3049bf6-51d0-4734-98e9-0be7ae5c0f88)
