### PR TITLE
feat: add snacks for image provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.DS_Store
+
 __pycache__/
 .venv/
 .direnv/

--- a/lua/load_snacks_nvim.lua
+++ b/lua/load_snacks_nvim.lua
@@ -1,0 +1,55 @@
+-- loads the snacks.nvim plugin and exposes methods to the python remote plugin
+local ok, snacks = pcall(require, "snacks")
+
+if not ok then
+  vim.api.nvim_echo({ { "[Molten] `snacks.nvim` not found" } }, true, { err = true })
+  return
+end
+
+local snacks_api = {}
+local images = {}
+
+snacks_api.from_file = function(path, opts)
+  opts.opts = {
+    inline = true,
+    pos = { opts.y, opts.x },
+    max_height = opts.max_height,
+    max_width = opts.max_width,
+  }
+  opts.placement = nil
+
+  images[path] = opts
+  return path
+end
+
+snacks_api.render = function(identifier)
+  local img = images[identifier]
+
+  if img.placement == nil then
+    img.placement = Snacks.image.placement.new(img.buffer, identifier, img.opts)
+  end
+end
+
+snacks_api.clear = function(identifier)
+  local img = images[identifier]
+  if img and img.placeement then
+    img.placement:close()
+    img.placement = nil
+  end
+end
+
+snacks_api.clear_all = function()
+  for _, img in pairs(images) do
+    snacks_api.clear(img)
+  end
+end
+
+--- try to estimate actual size based on raw image and snack opts. Actual rendered size is somewhat random but we cannot get it due to it not being available until after render()
+snacks_api.image_size = function(identifier)
+  local img = images[identifier]
+  local size =
+    snacks.image.util.fit(identifier, { width = img.opts.max_width, height = img.opts.max_height })
+  return size
+end
+
+return { snacks_api = snacks_api }

--- a/lua/load_snacks_nvim.lua
+++ b/lua/load_snacks_nvim.lua
@@ -13,8 +13,9 @@ snacks_api.from_file = function(path, opts)
   opts.opts = {
     inline = true,
     pos = { opts.y, opts.x },
-    max_height = opts.max_height,
-    max_width = opts.max_width,
+    -- Control max size by snacks config
+    max_width = snacks.config.image.doc.max_width,
+    max_height = snacks.config.image.doc.max_height,
   }
   opts.placement = nil
 
@@ -32,7 +33,7 @@ end
 
 snacks_api.clear = function(identifier)
   local img = images[identifier]
-  if img and img.placeement then
+  if img and img.placement then
     img.placement:close()
     img.placement = nil
   end

--- a/rplugin/python3/molten/images.py
+++ b/rplugin/python3/molten/images.py
@@ -313,9 +313,7 @@ class SnacksCanvas(Canvas):
                 "id": identifier,
                 "buffer": bufnr,
                 "x": x,
-                "y": y,
-                "max_width": 9999999,
-                "max_height": 9999999,
+                "y": y + 1,
             },
         )
         self.to_make_visible.add(img)

--- a/rplugin/python3/molten/images.py
+++ b/rplugin/python3/molten/images.py
@@ -259,15 +259,81 @@ class WeztermCanvas(Canvas):
         )
 
 
-def get_canvas_given_provider(
-    nvim: Nvim, options: MoltenOptions
-) -> Canvas:
+class SnacksCanvas(Canvas):
+    nvim: Nvim
+    to_make_visible: Set[str]
+    to_make_invisible: Set[str]
+    visible: Set[str]
+
+    def __init__(self, nvim: Nvim):
+        self.nvim = nvim
+        self.visible = set()
+        self.to_make_visible = set()
+        self.to_make_invisible = set()
+        self.next_id = 0
+
+    def init(self) -> None:
+        self.nvim.exec_lua("_snacks = require('load_snacks_nvim').snacks_api")
+        self.snacks_api = self.nvim.lua._snacks
+
+    def deinit(self) -> None:
+        self.snacks_api.clear_all()
+
+    def present(self) -> None:
+        # images to both show and hide should be ignored
+        to_work_on = self.to_make_visible.difference(
+            self.to_make_visible.intersection(self.to_make_invisible)
+        )
+        self.to_make_invisible.difference_update(self.to_make_visible)
+        for identifier in self.to_make_invisible:
+            self.snacks_api.clear(identifier)
+
+        for identifier in to_work_on:
+            self.snacks_api.render(identifier)
+
+        self.visible.update(self.to_make_visible)
+        self.to_make_invisible.clear()
+        self.to_make_visible.clear()
+
+    def img_size(self, identifier: str) -> Dict[str, int]:
+        return self.snacks_api.image_size(identifier)
+
+    def add_image(
+        self,
+        path: str,
+        identifier: str,
+        x: int,
+        y: int,
+        bufnr: int,
+        winnr: int | None = None,
+    ) -> str:
+        img = self.snacks_api.from_file(
+            path,
+            {
+                "id": identifier,
+                "buffer": bufnr,
+                "x": x,
+                "y": y,
+                "max_width": 9999999,
+                "max_height": 9999999,
+            },
+        )
+        self.to_make_visible.add(img)
+        return img
+
+    def remove_image(self, identifier: str) -> None:
+        self.to_make_invisible.add(identifier)
+
+
+def get_canvas_given_provider(nvim: Nvim, options: MoltenOptions) -> Canvas:
     name = options.image_provider
 
     if name == "none":
         return NoCanvas()
     elif name == "image.nvim":
         return ImageNvimCanvas(nvim)
+    elif name == "snacks.nvim":
+        return SnacksCanvas(nvim)
     elif name == "wezterm":
         if options.auto_open_output:
             raise MoltenException(

--- a/rplugin/python3/molten/outputbuffer.py
+++ b/rplugin/python3/molten/outputbuffer.py
@@ -160,7 +160,7 @@ class OutputBuffer:
             )
 
     def build_output_text(self, shape, buf: int, virtual: bool) -> Tuple[List[str], int]:
-        lineno = 1 # we add a status line at the top in the end
+        lineno = 1  # we add a status line at the top in the end
         lines_str = ""
         # images are rendered with virtual lines by image.nvim
         virtual_lines = 0
@@ -198,6 +198,10 @@ class OutputBuffer:
         # Remove trailing empty lines
         while len(lines) > 0 and lines[-1] == "":
             lines.pop()
+
+        # HACK: add an extra line for snacks image in windows
+        if self.options.image_provider == "snacks.nvim":
+            lines.append("")
 
         lines.insert(0, self._get_header_text(self.output))
         return lines, len(lines) - 1 + virtual_lines


### PR DESCRIPTION
Based on the work mentioned in https://github.com/benlubas/molten-nvim/discussions/285#discussioncomment-12290660 by @vekkt0r, I implemented further and fixed the bug of image being redrawn.

However, for `molten_virt_text_output = true`, I currently didn't manage to figure out the solution for the case where the previously rendered figure was not removed when rerunning. May need help here.

This may resolve #292 

PS: I prepared a screen recording for the demo but I cannot upload it here. If anyone knows how, please help me. As a workaround, I uploaded it to [YT](https://youtu.be/GrlwH1n62nM).