### PR TITLE
fix: handle backspace in output

### DIFF
--- a/rplugin/python3/molten/outputchunks.py
+++ b/rplugin/python3/molten/outputchunks.py
@@ -256,11 +256,11 @@ class Output:
             self.chunks.pop(prev_pos)
             chunk.text = prev_chunk.text + '\n'.join(lines)
             chunk.jupyter_data = {'text/plain': chunk.text}
-            if chunk.text == '':
-                self.chunks.pop()
         else:
             chunk.text = '\n'.join(lines)
             chunk.jupyter_data = {'text/plain': chunk.text}
+        if chunk.text == '':
+            self.chunks.pop()
 
 def to_outputchunk(
     nvim: Nvim,

--- a/rplugin/python3/molten/outputchunks.py
+++ b/rplugin/python3/molten/outputchunks.py
@@ -222,6 +222,26 @@ class Output:
         elif len(self.chunks) > 0 and isinstance((c1 := self.chunks[0]), TextOutputChunk):
             c1.text = "\n".join([re.sub(r".*\r", "", x) for x in c1.text.split("\n")[:-1]])
 
+    def handle_cross_chunk_backspace(self):
+        """Remove leading \b from the current chunk and the corresponding number of
+        characters from the previous chunk"""
+        if (
+            len(self.chunks) > 0
+            and isinstance((cur := self.chunks[-1]), TextOutputChunk)
+        ):
+            cur_len = len(cur.text)
+            bs_len = 0
+
+            while bs_len < cur_len and cur.text[bs_len] == '\b':
+                bs_len += 1
+
+            cur.text = cur.text[bs_len:]
+
+            if (
+                len(self.chunks) > 1
+                and isinstance((prev := self.chunks[-2]), TextOutputChunk)
+            ):
+                prev.text = prev.text[:-bs_len]
 
 def to_outputchunk(
     nvim: Nvim,

--- a/rplugin/python3/molten/runtime.py
+++ b/rplugin/python3/molten/runtime.py
@@ -121,8 +121,11 @@ class JupyterRuntime:
         if output.success:
             chunk = to_outputchunk(self.nvim, self._alloc_file, data, metadata, self.options)
             output.chunks.append(chunk)
-            if isinstance(chunk, TextOutputChunk) and chunk.text.startswith("\r"):
-                output.merge_text_chunks()
+            if isinstance(chunk, TextOutputChunk):
+                if chunk.text.startswith("\b"):
+                    output.handle_cross_chunk_backspace()
+                if chunk.text.startswith("\r"):
+                    output.merge_text_chunks()
 
     def _tick_one(self, output: Output, message_type: str, content: Dict[str, Any]) -> bool:
         def copy_on_demand(content_ctor):

--- a/rplugin/python3/molten/runtime.py
+++ b/rplugin/python3/molten/runtime.py
@@ -122,10 +122,7 @@ class JupyterRuntime:
             chunk = to_outputchunk(self.nvim, self._alloc_file, data, metadata, self.options)
             output.chunks.append(chunk)
             if isinstance(chunk, TextOutputChunk):
-                if chunk.text.startswith("\b"):
-                    output.handle_cross_chunk_backspace()
-                if chunk.text.startswith("\r"):
-                    output.merge_text_chunks()
+                output.process_text_chunk(chunk)
 
     def _tick_one(self, output: Output, message_type: str, content: Dict[str, Any]) -> bool:
         def copy_on_demand(content_ctor):


### PR DESCRIPTION
The fix for #308. Will not work properly if the `chunk.text` is a mix of stdout + stderr (if stderr is at the end of the chunck where characters must be backspaced it will be modified instead of the actual output that we are intersted in). Not sure if it is possible to make distinction between stdout and stderr in the `chunk.text`.