### PR TITLE
Avoid error on `snacks.nvim` provider for images

### DIFF
--- a/lua/load_snacks_nvim.lua
+++ b/lua/load_snacks_nvim.lua
@@ -14,8 +14,9 @@ snacks_api.from_file = function(path, opts)
     inline = true,
     pos = { opts.y, opts.x },
     -- Control max size by snacks config
-    max_width = snacks.config.image.doc.max_width,
-    max_height = snacks.config.image.doc.max_height,
+    -- FIX check if config has been set by user, use default instead
+    max_width = snacks.config.image.doc and snacks.config.image.doc.max_width or 80,
+    max_height = snacks.config.image.doc and  snacks.config.image.doc.max_height or 40,
   }
   opts.placement = nil
 


### PR DESCRIPTION
This avoids an error on `snacks.nvim` provider for images if empty config (using default) is used for the relative plugin.

If using default config for `snacks.image`, the table `doc` is `nil` and this of course raises an Error