### PR TITLE
feat: add standalone output capture with callback to MoltenEvaluateArgument

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ Below the header, output is shown.
 Jupyter provides a rich set of outputs. To see what we can currently handle, see [Output
 Chunks](#output-chunks).
 
+> [!TIP]
+> For advanced output handling (e.g., capturing output and writing to a buffer), see the [MoltenEvaluateArgument callback example](#moltenevaluateargument-callback-example) in the Functions section below.
+
 ### Commands
 
 These user commands are the main interface to the plugin. It is recommended to map most of them to
@@ -354,6 +357,91 @@ vim.fn.MoltenEvaluateRange("ir", 1, 3, 4, 20)
 
 _When there are multiple kernels attached to the buffer, and this function is called without
 a `kernel_id`, the user will be prompted for a kernel with vim.ui.select_
+
+</details>
+
+<details>
+  <summary>MoltenEvaluateArgument</summary>
+
+### MoltenEvaluateArgument Callback Example
+
+Molten supports capturing output from code execution and handling it in Lua via a callback. You can use **any Lua expression** as your callback, including global functions, module functions, or table fields. The callback is called using `exec_lua`, so you have full flexibility.
+
+#### Example 1: Global Function
+
+```lua
+function _G.molten_write_to_buffer(result)
+  local buf = vim.api.nvim_create_buf(false, true)
+  vim.api.nvim_buf_set_lines(buf, 0, -1, false, vim.split(result.output, "\n"))
+  vim.api.nvim_set_current_buf(buf)
+end
+
+vim.keymap.set('n', '<leader>ve', function()
+  local code = "print('hello world')"
+  vim.fn.MoltenEvaluateArgument(code, { on_done = "_G.molten_write_to_buffer" })
+end, { desc = 'Evaluate code and write output to buffer' })
+```
+
+#### Example 2: Module Function
+
+```lua
+-- lua/my_molten_config.lua
+local M = {}
+function M.write_to_buffer(result)
+  local buf = vim.api.nvim_create_buf(false, true)
+  vim.api.nvim_buf_set_lines(buf, 0, -1, false, vim.split(result.output, "\n"))
+  vim.api.nvim_set_current_buf(buf)
+end
+return M
+
+-- In your config
+vim.keymap.set('n', '<leader>ve', function()
+  local code = "print('hello world')"
+  vim.fn.MoltenEvaluateArgument(code, { on_done = "require('my_molten_config').write_to_buffer" })
+end, { desc = 'Evaluate code and write output to buffer' })
+```
+
+#### Example 3: Table Field
+
+```lua
+_G.my_callbacks = {}
+function _G.my_callbacks.write_to_buffer(result)
+  local buf = vim.api.nvim_create_buf(false, true)
+  vim.api.nvim_buf_set_lines(buf, 0, -1, false, vim.split(result.output, "\n"))
+  vim.api.nvim_set_current_buf(buf)
+end
+
+vim.keymap.set('n', '<leader>ve', function()
+  local code = "print('hello world')"
+  vim.fn.MoltenEvaluateArgument(code, { on_done = "_G.my_callbacks.write_to_buffer" })
+end, { desc = 'Evaluate code and write output to buffer' })
+```
+
+##### Notes:
+- The callback receives a table with keys:
+  - `output`: string, plain text output from the kernel
+  - `success`: boolean, whether execution succeeded
+  - `execution_count`: number, Jupyter execution count
+
+- You **must** pass the callback as a Lua expression string in the `on_done` field:
+  ```lua
+  { on_done = "require('my_molten_config').write_to_buffer" }
+  ```
+- Do **not** pass a Lua function directly; it will not work.
+
+#### Troubleshooting
+
+If you see an error like:
+```
+Error in standalone callback: Error executing Lua callback: ...
+```
+it means your callback expression was invalid or not in scope. Double-check your callback string and make sure the function is loaded and accessible.
+
+---
+
+**Summary:**
+- Pass any Lua expression as a string in the `on_done` field (global, module, or table function).
+- Molten will call your Lua function and you can handle output however you wish.
 
 </details>
 

--- a/rplugin/python3/molten/__init__.py
+++ b/rplugin/python3/molten/__init__.py
@@ -295,6 +295,23 @@ class Molten:
 
         kernel.run_code(expr, cell)
 
+    def _do_evaluate_standalone(self, kernel_name: str, expr: str, callback: Any) -> None:
+        """Execute code as a standalone evaluation with a callback (not tied to a cell)."""
+        self._initialize_if_necessary()
+
+        kernels = self._get_current_buf_kernels(True)
+        assert kernels is not None
+
+        kernel = None
+        for k in kernels:
+            if k.kernel_id == kernel_name:
+                kernel = k
+                break
+        if kernel is None:
+            raise MoltenException(f"Kernel {kernel_name} not found")
+
+        kernel.run_standalone_code(expr, callback)
+
     def _get_sorted_buf_cells(self, kernels: List[MoltenKernel], bufnr: int) -> List[CodeCell]:
         return sorted([x for x in chain(*[k.outputs.keys() for k in kernels]) if x.bufno == bufnr])
 
@@ -500,7 +517,7 @@ class Molten:
 
     @pynvim.command("MoltenEvaluateArgument", nargs="*", sync=True)  # type: ignore
     @nvimui
-    def commnand_molten_evaluate_argument(self, args: List[str]) -> None:
+    def command_molten_evaluate_argument(self, args: List[str]) -> None:
         if len(args) > 0 and args[0] in map(
             lambda x: x.kernel_id, self.buffers[self.nvim.current.buffer.number]
         ):
@@ -509,6 +526,95 @@ class Molten:
             self.kernel_check(
                 f"MoltenEvaluateArgument %k {' '.join(args)}", self.nvim.current.buffer
             )
+
+    @pynvim.function("MoltenEvaluateArgument", sync=False)  # type: ignore
+    @nvimui
+    def function_evaluate_argument(self, args: List[Any]) -> None:
+        """Function version of MoltenEvaluateArgument.
+        
+        Supports two forms:
+        1. Without callback (existing behavior, tied to cells):
+           vim.fn.MoltenEvaluateArgument("1 + 1")
+           vim.fn.MoltenEvaluateArgument("python3", "1 + 1")
+        
+        2. With callback (new standalone behavior, NOT tied to cells):
+           vim.fn.MoltenEvaluateArgument("print('hello')", {
+               on_done = function(result)
+                   -- result.output: string (plain text output)
+                   -- result.success: boolean
+                   -- result.execution_count: number
+                   print("Output: " .. result.output)
+               end
+           })
+           vim.fn.MoltenEvaluateArgument("python3", "print('hello')", {...})
+        """
+        if len(args) == 0:
+            return
+        
+        # Check if the last argument is a dict with on_done callback
+        callback_dict = None
+        if len(args) >= 1 and isinstance(args[-1], dict) and "on_done" in args[-1]:
+            callback_dict = args[-1]
+            args = args[:-1]
+        
+        # Parse arguments
+        kernel_name = None
+        code = None
+        
+        if len(args) == 1:
+            # Single argument: could be code or kernel name
+            # Try to determine if it's a kernel name by checking running kernels
+            current_buf_kernels = self.buffers.get(self.nvim.current.buffer.number, [])
+            kernel_ids = {k.kernel_id for k in current_buf_kernels}
+            if args[0] in kernel_ids:
+                kernel_name = args[0]
+                code = ""
+            else:
+                # It's code, need to determine kernel
+                code = args[0]
+        elif len(args) >= 2:
+            # First arg is kernel name, rest is code
+            kernel_name = args[0]
+            code = " ".join(args[1:])
+        else:
+            return
+        
+        # If kernel name not determined, use kernel_check to prompt
+        if kernel_name is None:
+            current_buf_kernels = self.buffers.get(self.nvim.current.buffer.number, [])
+            if callback_dict:
+                # If only one kernel, use it
+                if len(current_buf_kernels) == 1:
+                    kernel_name = current_buf_kernels[0].kernel_id
+                elif len(current_buf_kernels) > 1:
+                    # Prompt user to select kernel, then call again with selected kernel
+                    PROMPT = "Please select a kernel:"
+                    available_kernels = [kernel.kernel_id for kernel in current_buf_kernels]
+                    # Pass code and callback as arguments to the command
+                    self.nvim.lua._select_and_run(
+                        available_kernels,
+                        PROMPT,
+                        f"call MoltenEvaluateArgument('%k', '{code}', {callback_dict})"
+                    )
+                    return
+                else:
+                    notify_error(self.nvim, "No running kernel available for callback execution")
+                    return
+            else:
+                # No callback, use kernel_check to prompt/init
+                self.kernel_check(
+                    "call MoltenEvaluateArgument('%k')", self.nvim.current.buffer
+                )
+                return
+        
+        # Execute with or without callback
+        if callback_dict and "on_done" in callback_dict:
+            # Standalone execution with callback
+            callback = callback_dict["on_done"]
+            self._do_evaluate_standalone(kernel_name, code, callback)
+        else:
+            # Regular cell-based execution
+            self._do_evaluate_expr(kernel_name, code)
 
     @pynvim.command("MoltenEvaluateVisual", nargs="*", sync=True)  # type: ignore
     @nvimui  # type: ignore
@@ -1034,3 +1140,4 @@ class Molten:
                 outbuf = kern.outputs[cell]
                 outbuf.toggle_virtual_output(cell.end)
                 return
+

--- a/rplugin/python3/molten/moltenbuffer.py
+++ b/rplugin/python3/molten/moltenbuffer.py
@@ -13,7 +13,7 @@ from molten.images import Canvas
 from molten.position import Position
 from molten.utils import notify_error, notify_info, notify_warn
 from molten.outputbuffer import OutputBuffer
-from molten.outputchunks import ImageOutputChunk, OutputChunk, OutputStatus
+from molten.outputchunks import ImageOutputChunk, OutputChunk, OutputStatus, ErrorOutputChunk, TextOutputChunk, clean_up_text
 from molten.runtime import JupyterRuntime
 
 
@@ -42,6 +42,9 @@ class MoltenKernel:
 
     options: MoltenOptions
     output_statuses: Dict[Optional[CodeCell], OutputStatus]
+    
+    # Track standalone execution callbacks
+    standalone_callbacks: Dict[str, Callable]
 
     def __init__(
         self,
@@ -75,6 +78,7 @@ class MoltenKernel:
         self.updating_interface = False
 
         self.options = options
+        self.standalone_callbacks = {}
 
     def _doautocmd(self, autocmd: str, opts: Dict = {}) -> None:
         assert " " not in autocmd
@@ -126,6 +130,19 @@ class MoltenKernel:
         self.update_interface()
 
         self._check_if_done_running()
+
+    def run_standalone_code(self, code: str, callback: Callable) -> None:
+        """Execute code as a standalone execution (not tied to a cell) with a callback.
+        
+        Args:
+            code: The code to execute
+            callback: A callback function that takes a dict with keys:
+                - output: str (plain text output)
+                - success: bool
+                - execution_count: Optional[int]
+        """
+        msg_id = self.runtime.run_standalone_code(code)
+        self.standalone_callbacks[msg_id] = callback
 
     def reevaluate_all(self) -> None:
         for span in sorted(self.outputs.keys(), key=lambda s: s.begin):
@@ -260,6 +277,55 @@ class MoltenKernel:
                 self.nvim,
                 f"Kernel '{self.runtime.kernel_name}' (id: {self.kernel_id}) is ready.",
             )
+
+        # Process completed standalone outputs and fire callbacks
+        completed_standalone = self.runtime.get_completed_standalone_outputs()
+        for msg_id, output in completed_standalone:
+            if msg_id in self.standalone_callbacks:
+                callback = self.standalone_callbacks[msg_id]
+
+                # Build the result dict
+                result = {
+                    "success": output.success,
+                    "execution_count": output.execution_count,
+                }
+
+                # Extract plain text output from chunks
+                output_text = []
+                for chunk in output.chunks:
+                    if isinstance(chunk, TextOutputChunk):
+                        output_text.append(clean_up_text(chunk.text))
+                    elif isinstance(chunk, ErrorOutputChunk):
+                        # ErrorOutputChunk has extras dict with error details
+                        if chunk.extras:
+                            ename = chunk.extras.get('ename', 'Error')
+                            evalue = chunk.extras.get('evalue', '')
+                            traceback = chunk.extras.get('traceback', [])
+                            output_text.append(f"{ename}: {evalue}")
+                            if traceback:
+                                output_text.extend([clean_up_text(line) for line in traceback])
+                        else:
+                            # Fall back to the formatted text
+                            output_text.append(clean_up_text(chunk.text))
+                # Fallback: if output_text is empty, try to stringify all chunks
+                if not output_text and output.chunks:
+                    output_text = [str(chunk) for chunk in output.chunks]
+                result["output"] = "\n".join(output_text)
+
+                # Fire the callback
+                try:
+                    # If callback is a Python callable, call it directly
+                    if callable(callback):
+                        callback(result)
+                    else:
+                        # Flexible: allow any Lua expression as callback
+                        self.nvim.exec_lua(f"return {callback}(...)", result)
+                except Exception as e:
+                    notify_error(self.nvim, f"Error in standalone callback: {e}")
+
+                # Clean up
+                del self.standalone_callbacks[msg_id]
+                self.runtime.remove_standalone_output(msg_id)
 
     def tick_input(self) -> None:
         self.runtime.tick_input()

--- a/rplugin/python3/molten/runtime.py
+++ b/rplugin/python3/molten/runtime.py
@@ -36,6 +36,9 @@ class JupyterRuntime:
     options: MoltenOptions
     nvim: Nvim
 
+    # Track standalone executions by message ID
+    standalone_outputs: Dict[str, Output]
+
     def __init__(self, nvim: Nvim, kernel_name: str, kernel_id: str, options: MoltenOptions):
         self.state = RuntimeState.STARTING
         self.kernel_name = kernel_name
@@ -82,6 +85,7 @@ class JupyterRuntime:
 
         self.allocated_files = []
         self.options = options
+        self.standalone_outputs = {}
 
     def is_ready(self) -> bool:
         return self.state.value > RuntimeState.STARTING.value
@@ -103,7 +107,16 @@ class JupyterRuntime:
         self.kernel_manager.restart_kernel()
 
     def run_code(self, code: str) -> None:
+        """Execute code (cell-based execution)."""
         self.kernel_client.execute(code)
+
+    def run_standalone_code(self, code: str) -> str:
+        """Execute code as a standalone execution (not tied to a cell) and return the message ID."""
+        msg_id = self.kernel_client.execute(code)
+        # Create an Output object to track this standalone execution
+        self.standalone_outputs[msg_id] = Output(None)
+        self.standalone_outputs[msg_id].status = OutputStatus.HOLD
+        return msg_id
 
     @contextmanager
     def _alloc_file(
@@ -220,9 +233,7 @@ class JupyterRuntime:
             except RuntimeError:
                 return False
 
-        if output is None:
-            return did_stuff
-
+        # Process all messages in the queue
         while True:
             try:
                 message = self.kernel_client.get_iopub_msg(timeout=0)
@@ -230,15 +241,41 @@ class JupyterRuntime:
                 if "content" not in message or "msg_type" not in message:
                     continue
 
-                did_stuff_now = self._tick_one(output, message["msg_type"], message["content"])
-                did_stuff = did_stuff or did_stuff_now
+                # Check if this message belongs to a standalone execution
+                parent_msg_id = message.get("parent_header", {}).get("msg_id")
+                if parent_msg_id and parent_msg_id in self.standalone_outputs:
+                    # Route to standalone output
+                    standalone_output = self.standalone_outputs[parent_msg_id]
+                    did_stuff_now = self._tick_one(standalone_output, message["msg_type"], message["content"])
+                    did_stuff = did_stuff or did_stuff_now
+                    # Ensure OutputStatus.DONE is set on idle for standalone
+                    if message["msg_type"] == "status" and message["content"].get("execution_state") == "idle":
+                        standalone_output.status = OutputStatus.DONE
+                elif output is not None:
+                    # Route to cell-based output (existing behavior)
+                    did_stuff_now = self._tick_one(output, message["msg_type"], message["content"])
+                    did_stuff = did_stuff or did_stuff_now
 
-                if output.status == OutputStatus.DONE:
-                    break
+                    if output.status == OutputStatus.DONE:
+                        break
             except EmptyQueueException:
                 break
 
         return did_stuff
+
+
+    def get_completed_standalone_outputs(self) -> List[Tuple[str, Output]]:
+        """Get all completed standalone outputs and their message IDs."""
+        completed = []
+        for msg_id, output in list(self.standalone_outputs.items()):
+            if output.status == OutputStatus.DONE:
+                completed.append((msg_id, output))
+        return completed
+
+    def remove_standalone_output(self, msg_id: str) -> None:
+        """Remove a standalone output after its callback has been fired."""
+        if msg_id in self.standalone_outputs:
+            del self.standalone_outputs[msg_id]
 
     def tick_input(self):
         """Tick to check input_requests"""


### PR DESCRIPTION
This PR introduces support for capturing output from code execution in Molten via a Lua callback, without tying the execution to a cell.

Key changes:

- `MoltenEvaluateArgument` now has a function variant that accepts an `on_done` callback (as a Lua expression string) in an options table. This enables advanced output handling directly in user Lua code.
- Added new internal methods to handle standalone code execution and callback invocation.
- Output from standalone executions is collected, formatted as plain text (including error handling), and passed to the callback.
- Updated documentation with usage examples for global, module, and table-based Lua callbacks.
- Existing cell-based behavior is preserved; the new callback mechanism is opt-in.

This enables workflows such as capturing output and writing it to a new buffer, or custom post-processing of results, directly from Lua.

This whole idea started because I wanted to replicate VS Code's variable inspection feature, which lets you view current variable values from the active kernel session. Now, I can set up a callback that sends code to retrieve this information and, via a keymap, have it populate a floating buffer.

Example usage of callback to retrieve current user defined variables in active kernel:

- Show kernel variables/values in float
- Show kernel variables/values using fuzzy finder

https://github.com/user-attachments/assets/8742a55c-6d36-4dcd-b8db-cc656ade6ff6



