### PR TITLE
fix(output): fix rendering bugs for complex output (carriage return handling, progress bars, etc.)

### DIFF
--- a/rplugin/python3/molten/outputbuffer.py
+++ b/rplugin/python3/molten/outputbuffer.py
@@ -5,7 +5,7 @@ from pynvim import Nvim
 from pynvim.api import Buffer, Window
 
 from molten.images import Canvas
-from molten.outputchunks import ImageOutputChunk, Output, OutputStatus
+from molten.outputchunks import ImageOutputChunk, Output, OutputStatus, _resolve_cr
 from molten.options import MoltenOptions
 from molten.position import DynamicPosition, Position
 from molten.utils import notify_error
@@ -122,7 +122,7 @@ class OutputBuffer:
             time = ""
 
         if output.status == OutputStatus.NEW:
-            return f"Out[_]: Never Run"
+            return "Out[_]: Never Run"
         else:
             return f"{old}Out[{execution_count}]: {status} {time}".rstrip()
 
@@ -222,11 +222,24 @@ class OutputBuffer:
                 lines_str += chunktext
                 lineno += chunktext.count("\n")
                 virtual_lines += virt_lines
-                x = len(lines_str) - lines_str.rfind("\n")
+                # Update x to the column after the last newline, or to the length if no newline is present
+                last_newline = lines_str.rfind("\n")
+                if last_newline == -1:
+                    x = len(lines_str)
+                else:
+                    x = len(lines_str) - last_newline - 1
+
+            # Ensure any remaining carriage returns are resolved
+            lines_str = _resolve_cr(lines_str)
 
             limit = self.options.limit_output_chars
             if limit and len(lines_str) > limit:
-                lines_str = lines_str[:limit]
+                # Truncate at the last newline before the limit to avoid cutting a line in half
+                last_newline = lines_str.rfind("\n", 0, limit)
+                if last_newline > 0:
+                    lines_str = lines_str[:last_newline]
+                else:
+                    lines_str = lines_str[:limit]
                 lines_str += f"\n...truncated to {limit} chars\n"
 
             lines = lines_str.split("\n")

--- a/rplugin/python3/molten/outputbuffer.py
+++ b/rplugin/python3/molten/outputbuffer.py
@@ -6,7 +6,7 @@ from pynvim.api import Buffer, Window
 
 from molten.images import Canvas
 from molten.options import MoltenOptions
-from molten.outputchunks import ImageOutputChunk, Output, OutputStatus, _resolve_cr
+from molten.outputchunks import ImageOutputChunk, Output, OutputStatus, resolve_cr
 from molten.position import DynamicPosition, Position
 from molten.utils import notify_error
 
@@ -230,7 +230,7 @@ class OutputBuffer:
                     x = len(lines_str) - last_newline - 1
 
             # Ensure any remaining carriage returns are resolved
-            lines_str = _resolve_cr(lines_str)
+            lines_str = resolve_cr(lines_str)
 
             limit = self.options.limit_output_chars
             if limit and len(lines_str) > limit:

--- a/rplugin/python3/molten/outputbuffer.py
+++ b/rplugin/python3/molten/outputbuffer.py
@@ -1,12 +1,12 @@
 from datetime import datetime
-from typing import Any, List, Optional, Tuple, Union, Callable
+from typing import Any, Callable, List, Optional, Tuple, Union
 
 from pynvim import Nvim
 from pynvim.api import Buffer, Window
 
 from molten.images import Canvas
-from molten.outputchunks import ImageOutputChunk, Output, OutputStatus, _resolve_cr
 from molten.options import MoltenOptions
+from molten.outputchunks import ImageOutputChunk, Output, OutputStatus, _resolve_cr
 from molten.position import DynamicPosition, Position
 from molten.utils import notify_error
 

--- a/rplugin/python3/molten/outputchunks.py
+++ b/rplugin/python3/molten/outputchunks.py
@@ -1,20 +1,19 @@
+import re
+from abc import ABC, abstractmethod
+from contextlib import AbstractContextManager
+from datetime import datetime
+from enum import Enum
 from typing import (
-    Optional,
-    Tuple,
-    List,
-    Dict,
+    IO,
     Any,
     Callable,
-    IO,
+    Dict,
+    List,
+    Optional,
+    Tuple,
 )
-from contextlib import AbstractContextManager
-from enum import Enum
-from abc import ABC, abstractmethod
-import re
-from datetime import datetime
 
 from pynvim import Nvim
-
 
 from molten.images import Canvas
 from molten.options import MoltenOptions
@@ -287,12 +286,12 @@ def to_outputchunk(
             return _to_image_chunk(path)
 
     def _from_application_plotly(figure_json: Any) -> OutputChunk:
-        from plotly.io import from_json
+        import json
 
         # NOTE: import this to cause an import exception which we catch. instead of a different
         # error in `write_image`
         import kaleido  # type: ignore
-        import json
+        from plotly.io import from_json
 
         figure = from_json(json.dumps(figure_json))
 

--- a/rplugin/python3/molten/outputchunks.py
+++ b/rplugin/python3/molten/outputchunks.py
@@ -46,7 +46,7 @@ class OutputChunk(ABC):
 ANSI_CODE_REGEX = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
 
 
-def _resolve_cr(text: str) -> str:
+def resolve_cr(text: str) -> str:
     """Resolve carriage returns within text: keep text after last \\r per line."""
     lines = text.split("\n")
     processed = []
@@ -68,7 +68,7 @@ def clean_up_text(text: str) -> str:
     text = ANSI_CODE_REGEX.sub("", text)
     text = text.replace("\r\n", "\n")
     # Process standalone \r: simulate carriage return with proper overwrite
-    text = _resolve_cr(text)
+    text = resolve_cr(text)
     # Remove any trailing \r from each line for final display
     lines = text.split("\n")
     lines = [line.rstrip("\r") for line in lines]
@@ -244,11 +244,11 @@ class Output:
             and isinstance((c2 := self.chunks[-1]), TextOutputChunk)
         ):
             c1.text += c2.text
-            c1.text = _resolve_cr(c1.text)
+            c1.text = resolve_cr(c1.text)
             c1.jupyter_data = {"text/plain": c1.text}
             self.chunks.pop()
         elif len(self.chunks) > 0 and isinstance((c1 := self.chunks[-1]), TextOutputChunk):
-            c1.text = _resolve_cr(c1.text)
+            c1.text = resolve_cr(c1.text)
             c1.jupyter_data = {"text/plain": c1.text}
 
 

--- a/rplugin/python3/molten/outputchunks.py
+++ b/rplugin/python3/molten/outputchunks.py
@@ -47,13 +47,34 @@ class OutputChunk(ABC):
 ANSI_CODE_REGEX = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
 
 
+def _resolve_cr(text: str) -> str:
+    """Resolve carriage returns within text: keep text after last \\r per line."""
+    lines = text.split("\n")
+    processed = []
+    for line in lines:
+        if "\r" in line:
+            # Split by \r and keep the last segment
+            parts = line.split("\r")
+            # If line ends with \r (empty last part), take second-to-last and preserve \r
+            if parts[-1] == "" and len(parts) > 1:
+                line = parts[-2] + "\r"
+            else:
+                # Otherwise take the last part (text after last \r)
+                line = parts[-1]
+        processed.append(line)
+    return "\n".join(processed)
+
+
 def clean_up_text(text: str) -> str:
-    return (
-        ANSI_CODE_REGEX
-        .sub("", text)
-        .replace("\r\n", "\n")
-        .replace("\n\n", "\n")
-    )
+    text = ANSI_CODE_REGEX.sub("", text)
+    text = text.replace("\r\n", "\n")
+    # Process standalone \r: simulate carriage return with proper overwrite
+    text = _resolve_cr(text)
+    # Remove any trailing \r from each line for final display
+    lines = text.split("\n")
+    lines = [line.rstrip("\r") for line in lines]
+    text = "\n".join(lines)
+    return text
 
 
 class TextOutputChunk(OutputChunk):
@@ -83,27 +104,31 @@ class TextOutputChunk(OutputChunk):
             win_width = shape[2]
             if hard_wrap:
                 lines = []
-                splits = []
-                # Assume this is a progress bar, or similar, we shouldn't try to wrap it
-                if text.find("\r") != -1:
-                    return text, 0
-                for line in text.split("\n"):
-                    index = 0
-                    if len(line) + col > win_width:
-                        splits.append(line[: win_width - col])
-                        line = line[win_width - col :]
+                for i, line in enumerate(text.split("\n")):
+                    effective_col = col if i == 0 else 0
+                    splits = []
+                    if len(line) + effective_col > win_width:
+                        splits.append(line[: win_width - effective_col])
+                        line = line[win_width - effective_col :]
+                    else:
+                        splits.append(line)
+                        lines.extend(splits)
+                        continue
 
+                    index = 0
                     for _ in range(len(line) // win_width):
                         splits.append(line[index * win_width : (index + 1) * win_width])
                         index += 1
-                    splits.append(line[index * win_width :])
+                    if line[index * win_width :]:
+                        splits.append(line[index * win_width :])
 
-                lines.extend(splits)
+                    lines.extend(splits)
                 text = "\n".join(lines)
             else:
-                for line in text.split("\n"):
-                    if len(line) > win_width:
-                        extra_lines += len(line) // win_width
+                for i, line in enumerate(text.split("\n")):
+                    effective_width = win_width - col if i == 0 else win_width
+                    if len(line) > effective_width:
+                        extra_lines += (len(line) - effective_width + win_width - 1) // win_width
 
         return text, extra_lines
 
@@ -135,6 +160,8 @@ class ErrorOutputChunk(TextLnOutputChunk):
             )
         )
         self.output_type = "error"
+        self.jupyter_data = {"text/plain": self.text}
+        self.jupyter_metadata = {}
 
 
 class AbortedOutputChunk(TextLnOutputChunk):
@@ -211,19 +238,19 @@ class Output:
         self._should_clear = False
 
     def merge_text_chunks(self):
-        """Merge the last two chunks if they are text chunks, and text on a line before \r
-        character, this is b/c outputs before a \r aren't shown, and so, should be deleted"""
+        """Merge the last two text chunks and resolve carriage returns."""
         if (
             len(self.chunks) >= 2
             and isinstance((c1 := self.chunks[-2]), TextOutputChunk)
             and isinstance((c2 := self.chunks[-1]), TextOutputChunk)
         ):
             c1.text += c2.text
-            c1.text = "\n".join([re.sub(r".*\r", "", x) for x in c1.text.split("\n")[:-1]])
+            c1.text = _resolve_cr(c1.text)
             c1.jupyter_data = {"text/plain": c1.text}
             self.chunks.pop()
-        elif len(self.chunks) > 0 and isinstance((c1 := self.chunks[0]), TextOutputChunk):
-            c1.text = "\n".join([re.sub(r".*\r", "", x) for x in c1.text.split("\n")[:-1]])
+        elif len(self.chunks) > 0 and isinstance((c1 := self.chunks[-1]), TextOutputChunk):
+            c1.text = _resolve_cr(c1.text)
+            c1.jupyter_data = {"text/plain": c1.text}
 
 
 def to_outputchunk(
@@ -321,7 +348,7 @@ def to_outputchunk(
         if data is not None and data.get("text/plain"):
             chunk = _from_plaintext(data["text/plain"])
         else:
-            if data == None:
+            if data is None:
                 data = {}
             chunk = BadOutputChunk(list(data.keys()))
 

--- a/rplugin/python3/molten/runtime.py
+++ b/rplugin/python3/molten/runtime.py
@@ -1,26 +1,26 @@
-from datetime import datetime
-from typing import Optional, Tuple, List, Dict, Generator, IO, Any
-from contextlib import contextmanager
-from queue import Empty as EmptyQueueException
+import json
 import os
 import tempfile
-import json
+from contextlib import contextmanager
+from datetime import datetime
+from queue import Empty as EmptyQueueException
+from typing import IO, Any, Dict, Generator, List, Optional, Tuple
 
 import jupyter_client
 from pynvim import Nvim
 
+from molten.jupyter_server_api import JupyterAPIClient, JupyterAPIManager
 from molten.options import MoltenOptions
 from molten.outputchunks import (
-    Output,
-    MimetypesOutputChunk,
     ErrorOutputChunk,
-    TextOutputChunk,
+    MimetypesOutputChunk,
+    Output,
     OutputStatus,
-    to_outputchunk,
+    TextOutputChunk,
     clean_up_text,
+    to_outputchunk,
 )
 from molten.runtime_state import RuntimeState
-from molten.jupyter_server_api import JupyterAPIClient, JupyterAPIManager
 
 
 class JupyterRuntime:

--- a/rplugin/python3/molten/runtime.py
+++ b/rplugin/python3/molten/runtime.py
@@ -183,24 +183,14 @@ class JupyterRuntime:
             copy_on_demand(content["text"])
             text = content["text"]
 
-            # Check for standalone \r (progress updates, not \r\n)
-            has_standalone_cr = "\r" in text.replace("\r\n", "")
+            # Preserve exact stream semantics (including \n / \r) by using TextOutputChunk directly.
+            chunk = TextOutputChunk(text)
+            chunk.jupyter_data = {"text/plain": text}
+            chunk.jupyter_metadata = {}
+            output.chunks.append(chunk)
 
-            if has_standalone_cr:
-                # For progress updates, use TextOutputChunk (no added newline)
-                # This allows in-place updates like VS Code's behavior
-                chunk = TextOutputChunk(text)
-                chunk.jupyter_data = {"text/plain": text}
-                chunk.jupyter_metadata = {}
-                output.chunks.append(chunk)
-                output.merge_text_chunks()
-            else:
-                # Normal output - strip trailing \n to avoid double newlines
-                # (TextLnOutputChunk will add one)
-                text = text.rstrip("\n")
-                # Only create chunk if there's actual text (avoid BadOutputChunk for empty strings)
-                if text:
-                    self._append_chunk(output, {"text/plain": text}, {})
+            # Merge adjacent text chunks and resolve carriage returns once, centrally.
+            output.merge_text_chunks()
             return True
         elif message_type == "display_data":
             # XXX: consider content['transient'], if we end up saving execution

--- a/rplugin/python3/molten/runtime.py
+++ b/rplugin/python3/molten/runtime.py
@@ -121,7 +121,7 @@ class JupyterRuntime:
         if output.success:
             chunk = to_outputchunk(self.nvim, self._alloc_file, data, metadata, self.options)
             output.chunks.append(chunk)
-            if isinstance(chunk, TextOutputChunk) and chunk.text.startswith("\r"):
+            if isinstance(chunk, TextOutputChunk) and "\r" in chunk.text:
                 output.merge_text_chunks()
 
     def _tick_one(self, output: Output, message_type: str, content: Dict[str, Any]) -> bool:
@@ -181,7 +181,26 @@ class JupyterRuntime:
             return True
         elif message_type == "stream":
             copy_on_demand(content["text"])
-            self._append_chunk(output, {"text/plain": content["text"]}, {})
+            text = content["text"]
+
+            # Check for standalone \r (progress updates, not \r\n)
+            has_standalone_cr = "\r" in text.replace("\r\n", "")
+
+            if has_standalone_cr:
+                # For progress updates, use TextOutputChunk (no added newline)
+                # This allows in-place updates like VS Code's behavior
+                chunk = TextOutputChunk(text)
+                chunk.jupyter_data = {"text/plain": text}
+                chunk.jupyter_metadata = {}
+                output.chunks.append(chunk)
+                output.merge_text_chunks()
+            else:
+                # Normal output - strip trailing \n to avoid double newlines
+                # (TextLnOutputChunk will add one)
+                text = text.rstrip("\n")
+                # Only create chunk if there's actual text (avoid BadOutputChunk for empty strings)
+                if text:
+                    self._append_chunk(output, {"text/plain": text}, {})
             return True
         elif message_type == "display_data":
             # XXX: consider content['transient'], if we end up saving execution
@@ -247,8 +266,7 @@ class JupyterRuntime:
 
         assert isinstance(
             self.kernel_client,
-            (jupyter_client.blocking.client.BlockingKernelClient,
-             JupyterAPIClient),
+            (jupyter_client.blocking.client.BlockingKernelClient, JupyterAPIClient),
         )
 
         try:

--- a/rplugin/python3/molten/save_load.py
+++ b/rplugin/python3/molten/save_load.py
@@ -22,10 +22,8 @@ class MoltenIOError(Exception):
             raise cls(f"Missing key: {key}")
         value = data[key]
         if type_ is not None and not isinstance(value, type_):
-            raise cls(
-                f"Incorrect type for key '{key}': expected {type_.__name__}, \
-                got {type(value).__name__}"
-            )
+            raise cls(f"Incorrect type for key '{key}': expected {type_.__name__}, \
+                got {type(value).__name__}")
         return value
 
 
@@ -131,11 +129,12 @@ def save(molten_kernel: MoltenKernel, nvim_buffer: int) -> Dict[str, Any]:
                 "success": output.output.success,
                 "chunks": [
                     {
-                        "data": chunk.jupyter_data,
-                        "metadata": chunk.jupyter_metadata,
+                        "data": chunk.jupyter_data if chunk.jupyter_data is not None else {},
+                        "metadata": (
+                            chunk.jupyter_metadata if chunk.jupyter_metadata is not None else {}
+                        ),
                     }
                     for chunk in output.output.chunks
-                    if chunk.jupyter_data is not None and chunk.jupyter_metadata is not None
                 ],
             }
             for span, output in molten_kernel.outputs.items()

--- a/rplugin/python3/molten/save_load.py
+++ b/rplugin/python3/molten/save_load.py
@@ -1,16 +1,16 @@
-from typing import Type, Optional, Dict, Any
 import os
+from typing import Any, Dict, Optional, Type
+
 from pynvim import Nvim
-
 from pynvim.api import Buffer
-from molten.code_cell import CodeCell
-from molten.position import DynamicPosition
 
-from molten.utils import MoltenException
-from molten.options import MoltenOptions
-from molten.outputchunks import OutputStatus, Output, to_outputchunk
-from molten.outputbuffer import OutputBuffer
+from molten.code_cell import CodeCell
 from molten.moltenbuffer import MoltenKernel
+from molten.options import MoltenOptions
+from molten.outputbuffer import OutputBuffer
+from molten.outputchunks import Output, OutputStatus, to_outputchunk
+from molten.position import DynamicPosition
+from molten.utils import MoltenException
 
 
 class MoltenIOError(Exception):
@@ -22,8 +22,10 @@ class MoltenIOError(Exception):
             raise cls(f"Missing key: {key}")
         value = data[key]
         if type_ is not None and not isinstance(value, type_):
-            raise cls(f"Incorrect type for key '{key}': expected {type_.__name__}, \
-                got {type(value).__name__}")
+            raise cls(
+                f"Incorrect type for key '{key}': expected {type_.__name__}, \
+                got {type(value).__name__}"
+            )
         return value
 
 

--- a/rplugin/python3/molten/save_load.py
+++ b/rplugin/python3/molten/save_load.py
@@ -131,10 +131,8 @@ def save(molten_kernel: MoltenKernel, nvim_buffer: int) -> Dict[str, Any]:
                 "success": output.output.success,
                 "chunks": [
                     {
-                        "data": chunk.jupyter_data if chunk.jupyter_data is not None else {},
-                        "metadata": (
-                            chunk.jupyter_metadata if chunk.jupyter_metadata is not None else {}
-                        ),
+                        "data": chunk.jupyter_data or {},
+                        "metadata": (chunk.jupyter_metadata or {}),
                     }
                     for chunk in output.output.chunks
                 ],


### PR DESCRIPTION
## Description

This commit consolidates multiple improvements and bug fixes related to output rendering, carriage return logic, and progress bar handling across the codebase.

## Key changes:

- Improved carriage return (\r) handling to ensure proper terminal overwrite and accurate merging of output chunks.
- Enhanced hard wrap logic and column tracking in outputbuffer.py to prevent character truncation and blank line issues.
- Fixed error chunk persistence by handling None values during save/load operations.
- Consolidated stream message handling and improved carriage return detection in runtime.py.
- Addressed progress bar in-place updates to display only the final state, using TextOutputChunk for \r updates and stripping trailing newlines to avoid blank lines.
- Fixed a mime type error caused by empty print() statements after progress bar completion.

## Before

https://github.com/user-attachments/assets/735ac6c3-4b69-47a3-8076-ed940096e895

## After

https://github.com/user-attachments/assets/f655e0e1-87c7-47cc-8169-10e26c854b40
