### PR TITLE
fix(outputbuffer): correct calculation of minutes and seconds in time diff

### DIFF
--- a/rplugin/python3/molten/outputbuffer.py
+++ b/rplugin/python3/molten/outputbuffer.py
@@ -102,8 +102,8 @@ class OutputBuffer:
 
             days = diff.days
             hours = diff.seconds // 3600
-            minutes = diff.seconds // 60
-            seconds = diff.seconds - hours * 3600 - minutes * 60
+            minutes = (diff.seconds % 3600) // 60
+            seconds = diff.seconds % 60
             microseconds = diff.microseconds
 
             time = ""


### PR DESCRIPTION
The calculation for minutes and seconds in the time difference was incorrect resulting in negative seconds and incorrect time diff after 60 minutes. Minutes are now computed as the remainder after hours, and seconds as the remainder after minutes, ensuring accurate time formatting.