### PR TITLE
feat: add opt-in output_win_q_close option to close output window with q

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,8 @@ variable, their values, and a brief description.
 | `g:molten_output_win_cover_gutter`            | (`true`) \| `false`                                         | Should the output window cover the gutter (numbers and sign col), or not. If you change this, you probably also want to change `molten_output_win_style` |
 | `g:molten_output_win_hide_on_leave`           | (`true`) \| `false`                                         | After leaving the output window (via `:q` or switching windows), do not attempt to redraw the output window |
 | `g:molten_output_win_max_height`              | (`999999`) \| int                                           | Max height of the output window |
-| `g:molten_output_win_max_width`               | (`999999`) \| int                                           | Max width of the output window |
+| `g:molten_output_win_max_width`               | (`999999`) \| int                                          | Max width of the output window |
+| `g:molten_output_win_q_close`                 | `true` \| (`false`)                                        | When true, pressing `q` in the output window will close it |
 | `g:molten_output_win_style`                   | (`false`) \| `"minimal"`                                    | Value passed to the `style` option in `:h nvim_open_win()` |
 | `g:molten_save_path`                          | (`stdpath("data").."/molten"`) \| any path to a folder      | Where to save/load data with `:MoltenSave` and `:MoltenLoad` |
 | `g:molten_split_direction`                    | (`"right"`) \| `"left"` \| `"top"` \| `"bottom"` \|         | Direction of the terminal split created by wezterm. *Only applies if `g:molten_image_provider = "wezterm"`* |

--- a/rplugin/python3/molten/options.py
+++ b/rplugin/python3/molten/options.py
@@ -52,6 +52,7 @@ class MoltenOptions:
     output_win_hide_on_leave: bool
     output_win_max_height: int
     output_win_max_width: int
+    output_win_q_close: bool
     output_win_style: Optional[str]
     output_win_zindex: Optional[str]
     save_path: str
@@ -95,6 +96,7 @@ class MoltenOptions:
             ("molten_output_win_hide_on_leave", True),
             ("molten_output_win_max_height", 999999),
             ("molten_output_win_max_width", 999999),
+            ("molten_output_win_q_close", False),
             ("molten_output_win_style", False),
             ("molten_save_path", os.path.join(nvim.funcs.stdpath("data"), "molten")),
             ("molten_split_direction", "right"),

--- a/rplugin/python3/molten/outputbuffer.py
+++ b/rplugin/python3/molten/outputbuffer.py
@@ -362,6 +362,13 @@ class OutputBuffer:
         self.nvim.api.set_option_value(
             "filetype", "molten_output", {"buf": self.display_buf.handle}
         )
+        if self.options.output_win_q_close:
+            self.display_buf.api.set_keymap(
+                "n",
+                "q",
+                "<cmd>close<CR>",
+                {"noremap": True, "silent": True},
+            )
 
         # Open output window
         # assert self.display_window is None


### PR DESCRIPTION
User-side `FileType` autocmds are unreliable for mapping keys in Molten's output buffer because Molten creates and reuses a single persistent scratch buffer, setting `filetype` programmatically — so the autocmd event is typically missed. The fix is to wire the mapping directly into Molten's buffer lifecycle.

## Changes

- **`options.py`** — adds `output_win_q_close: bool` field to `MoltenOptions` and registers `molten_output_win_q_close` in `CONFIG_VARS` with default `False`
- **`outputbuffer.py`** — in `show_floating_win()`, after `filetype=molten_output` is set, conditionally applies a buffer-local `noremap silent n q <cmd>close<CR>` on `self.display_buf` when the option is enabled
- **`README.md`** — documents the new option in the configuration table

## Usage

```lua
vim.g.molten_output_win_q_close = true
```

No behavior change for existing users — opt-in only.