### PR TITLE
fix(runtime): fix is_ready check in tick_input

### DIFF
--- a/rplugin/python3/molten/runtime.py
+++ b/rplugin/python3/molten/runtime.py
@@ -242,7 +242,7 @@ class JupyterRuntime:
 
     def tick_input(self):
         """Tick to check input_requests"""
-        if not self.is_ready:
+        if not self.is_ready():
             return
 
         assert isinstance(


### PR DESCRIPTION
Fix the readiness check in `JupyterRuntime.tick_input()`.

`is_ready()` is a method, but `tick_input` currently checks the method object itself instead of calling it. Since bound methods are truthy, the guard never returns.

This changes `self.is_ready` to `self.is_ready()`, matching he existing usage in `tick()`.

Testing: 
- Inspected the related `tick()` and `is_ready()` logic.